### PR TITLE
[tag] make new release version before big changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # see semver.org for version info
-AC_INIT([libnrm],[0.1.0],[swann@anl.gov])
+AC_INIT([libnrm],[0.7.0],[swann@anl.gov])
 
 
 # are we in the right source dir ?


### PR DESCRIPTION
xgitlab had a 0.6 tag across the hnrm repo. Mark the current state as a
new version and preserve our ability to fix small stuff before we start
to make this repo into a bigger deal.