### PR TITLE
provide getcpu on systems with an old libc

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -54,6 +54,25 @@ jobs:
           name: out-of-tree
           path: |
             out/config.log
+  old:
+    runs-on: ubuntu-18.04
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 gfortran
+      - uses: actions/checkout@v2
+      - name: configure
+        run: |
+          ./autogen.sh
+          mkdir build
+          ./configure --prefix=`pwd`/build
+      - run: make
+      - run: make install
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: old
+          path: |
+            config.log
   nix:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ libnrm_la_SOURCES = \
 		    src/timers.c \
 		    src/scopes.c \
 		    src/bitmaps.c
-libnrm_la_LIBADD = @LIBZMQ_LIBS@
+libnrm_la_LIBADD = @LIBZMQ_LIBS@ $(LTLIBOBJS)
 
 libnrmf_la_SOURCES = \
 		     src/downstream_api.c \
@@ -26,4 +26,4 @@ libnrmf_la_SOURCES = \
 		     src/timers.c \
 		     src/scopes.c \
 		     src/bitmaps.c
-libnrmf_la_LIBADD = @LIBZMQ_LIBS@
+libnrmf_la_LIBADD = @LIBZMQ_LIBS@ $(LTLIBOBJS)

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_CONFIG_SRCDIR([src/nrm.h])
 # build artefacts in separate dir
 AC_CONFIG_AUX_DIR([m4])
 AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_LIBOBJ_DIR([lib])
 
 # automake should fail on any error
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects 1.12])
@@ -23,6 +24,9 @@ AC_TYPE_INTPTR_T
 AC_PROG_FC
 AC_FC_WRAPPERS
 AM_PROG_AR
+
+# getcpu is somewhat new, and might be missing from the system libc
+AC_REPLACE_FUNCS(getcpu)
 
 # dependencies
 PKG_CHECK_MODULES([LIBZMQ],[libzmq])

--- a/lib/getcpu.c
+++ b/lib/getcpu.c
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the libnrm project.
+ * For more info, see https://github.com/anlsys/libnrm
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+#include "config.h"
+
+#include <sched.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef HAVE_GETCPU
+int getcpu(unsigned int *cpu, unsigned int *node)
+{
+	/* the syscall has an extra unused parameter */
+	return syscall(SYS_getcpu, cpu, node, NULL);
+}
+#endif

--- a/src/scopes.c
+++ b/src/scopes.c
@@ -17,6 +17,10 @@
 
 #include "nrm.h"
 
+#ifndef HAVE_GETCPU
+int getcpu(unsigned int *cpu, unsigned int *node);
+#endif
+
 struct nrm_scope {
 	struct nrm_bitmap maps[NRM_SCOPE_TYPE_MAX];
 };


### PR DESCRIPTION
While the syscall itself is old, it is missing as a function from old versions of the glibc. This pull request uses the autoconf facilities for checking functions to test whether the function exists, and provide an alternative implementation if needed.