### PR TITLE
[fix] client code not updating data on return

### DIFF
--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -84,6 +84,11 @@ int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_uuid_t *uuid);
 nrm_scope_t *nrm_scope_create_frommsg(nrm_msg_scope_t *msg);
 nrm_slice_t *nrm_slice_create_frommsg(nrm_msg_slice_t *msg);
 nrm_sensor_t *nrm_sensor_create_frommsg(nrm_msg_sensor_t *msg);
+
+int nrm_scope_update_frommsg(nrm_scope_t *scope, nrm_msg_scope_t *msg);
+int nrm_slice_update_frommsg(nrm_slice_t *slice, nrm_msg_slice_t *msg);
+int nrm_sensor_update_frommsg(nrm_sensor_t *sensor, nrm_msg_sensor_t *msg);
+
 /*******************************************************************************
  * Printing
  ******************************************************************************/

--- a/src/client.c
+++ b/src/client.c
@@ -64,7 +64,7 @@ int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope)
 
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SCOPE);
-	scope = nrm_scope_create_frommsg(msg->add->scope);
+	nrm_scope_update_frommsg(scope, msg->add->scope);
 	return 0;
 }
 
@@ -90,7 +90,7 @@ int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice)
 
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SLICE);
-	slice = nrm_slice_create_frommsg(msg->add->slice);
+	nrm_slice_update_frommsg(slice, msg->add->slice);
 	return 0;
 }
 
@@ -116,7 +116,7 @@ int nrm_client_add_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
 
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SENSOR);
-	sensor = nrm_sensor_create_frommsg(msg->add->sensor);
+	nrm_sensor_update_frommsg(sensor, msg->add->sensor);
 	return 0;
 }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -337,6 +337,38 @@ nrm_slice_t *nrm_slice_create_frommsg(nrm_msg_slice_t *msg)
 	return ret;
 }
 
+int nrm_scope_update_frommsg(nrm_scope_t *scope, nrm_msg_scope_t *msg)
+{
+	if (scope == NULL || msg == NULL)
+		return -NRM_EINVAL;
+	nrm_bitmap_from_array(&scope->maps[NRM_SCOPE_TYPE_CPU], msg->n_cpus,
+	                      msg->cpus);
+	nrm_bitmap_from_array(&scope->maps[NRM_SCOPE_TYPE_NUMA], msg->n_numas,
+	                      msg->numas);
+	nrm_bitmap_from_array(&scope->maps[NRM_SCOPE_TYPE_GPU], msg->n_gpus,
+	                      msg->gpus);
+	return 0;
+}
+
+int nrm_sensor_update_frommsg(nrm_sensor_t *sensor, nrm_msg_sensor_t *msg)
+{
+	if (sensor == NULL || msg == NULL)
+		return -NRM_EINVAL;
+	sensor->name = nrm_string_fromchar(msg->name);
+	if (msg->uuid)
+		sensor->uuid = nrm_uuid_create_fromchar(msg->uuid);
+	return 0;
+}
+
+int nrm_slice_update_frommsg(nrm_slice_t *slice, nrm_msg_slice_t *msg)
+{
+	if (slice == NULL || msg == NULL)
+		return -NRM_EINVAL;
+	slice->name = nrm_string_fromchar(msg->name);
+	if (msg->uuid)
+		slice->uuid = nrm_uuid_create_fromchar(msg->uuid);
+	return 0;
+}
 /*******************************************************************************
  * Protobuf Management: ZMQ Management
  *******************************************************************************/
@@ -741,7 +773,6 @@ int nrm_ctrlmsg_sendmsg(zsock_t *socket,
                         nrm_msg_t *msg,
                         nrm_uuid_t *to)
 {
-	assert(type == NRM_CTRLMSG_TYPE_SEND);
 	return nrm_ctrlmsg__send(socket, type, (void *)msg, (void *)to);
 }
 
@@ -765,7 +796,6 @@ nrm_msg_t *nrm_ctrlmsg_recvmsg(zsock_t *socket, int *type, nrm_uuid_t **from)
 	int err;
 	void *p, *q;
 	err = nrm_ctrlmsg__recv(socket, type, &p, &q);
-	assert(type == NRM_CTRLMSG_TYPE_RECV);
 	nrm_log_printmsg(NRM_LOG_DEBUG, (nrm_msg_t *)p);
 	if (from != NULL) {
 		*from = (nrm_uuid_t *)q;

--- a/src/utils/bitmaps.c
+++ b/src/utils/bitmaps.c
@@ -95,6 +95,12 @@ int nrm_bitmap_cmp(struct nrm_bitmap *one, struct nrm_bitmap *two)
 	return memcmp(one->mask, two->mask, NRM_BITMAP_BYTES);
 }
 
+int nrm_bitmap_reset(struct nrm_bitmap *bitmap)
+{
+	memset(bitmap->mask, 0, NRM_BITMAP_BYTES);
+	return 0;
+}
+
 /**
  * Bitmap conversion to string. Output strings are index numbers wrapped in
  *brackets [].
@@ -174,6 +180,7 @@ int nrm_bitmap_to_array(const struct nrm_bitmap *map,
 
 int nrm_bitmap_from_array(struct nrm_bitmap *map, size_t nitems, int32_t *items)
 {
+	nrm_bitmap_reset(map);
 	for (size_t i = 0; i < nitems; i++)
 		nrm_bitmap_set(map, items[i]);
 	return 0;
@@ -186,6 +193,7 @@ int nrm_bitmap_from_json(struct nrm_bitmap *bitmap, json_t *json)
 
 	size_t index;
 	json_t *value;
+	nrm_bitmap_reset(bitmap);
 	json_array_foreach(json, index, value)
 	{
 		json_int_t i = json_integer_value(value);


### PR DESCRIPTION
Update the sensor/slice/scope during add with the
return message, instead of trying to create a new
object.

Still plenty of places where the pointer logic is sketchy.