### PR TITLE
[feature] actuators

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,7 +117,9 @@ nrmd_SOURCES = src/binaries/nrmd.c
 nrmd_LDADD = libnrm.la
 nrmc_SOURCES = src/binaries/nrmc.c
 nrmc_LDADD = libnrm.la
-bin_PROGRAMS += nrmd nrmc
+nrm_dummy_extra_SOURCES = src/binaries/nrm-dummy-extra.c
+nrm_dummy_extra_LDADD = libnrm.la
+bin_PROGRAMS += nrmd nrmc nrm-dummy-extra
 endif
 
 dist_noinst_DATA = src/msg.proto

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,7 @@ noinst_HEADERS = \
 lib_LTLIBRARIES = libnrm.la
 
 libnrm_la_SOURCES = \
+		 src/actuator.c \
 		 src/client.c \
 		 src/eventbase.c \
 		 src/net.c \

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz") {}
+{ pkgs ? import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/22.05.tar.gz") {}
 }:
 let
   callPackage = pkgs.lib.callPackageWith pkgs;

--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -33,7 +33,8 @@ typedef enum _Nrm__MSGTYPE nrm_msg_msgtype_e;
 #define NRM_MSG_TYPE_ADD (NRM__MSGTYPE__ADD)
 #define NRM_MSG_TYPE_REMOVE (NRM__MSGTYPE__REMOVE)
 #define NRM_MSG_TYPE_EVENT (NRM__MSGTYPE__EVENT)
-#define NRM_MSG_TYPE_MAX (5)
+#define NRM_MSG_TYPE_ACTUATE (NRM__MSGTYPE__ACTUATE)
+#define NRM_MSG_TYPE_MAX (6)
 
 typedef enum _Nrm__TARGETTYPE nrm_msg_targettype_e;
 #define NRM_MSG_TARGET_TYPE_SLICE (NRM__TARGETTYPE__SLICE)
@@ -42,6 +43,7 @@ typedef enum _Nrm__TARGETTYPE nrm_msg_targettype_e;
 #define NRM_MSG_TARGET_TYPE_ACTUATOR (NRM__TARGETTYPE__ACTUATOR)
 #define NRM_MSG_TARGET_TYPE_MAX (4)
 
+typedef Nrm__Actuate nrm_msg_actuate_t;
 typedef Nrm__Actuator nrm_msg_actuator_t;
 typedef Nrm__ActuatorList nrm_msg_actuatorlist_t;
 typedef Nrm__Add nrm_msg_add_t;
@@ -55,6 +57,7 @@ typedef Nrm__SensorList nrm_msg_sensorlist_t;
 typedef Nrm__Slice nrm_msg_slice_t;
 typedef Nrm__SliceList nrm_msg_slicelist_t;
 
+#define nrm_msg_actuate_init(msg) nrm__actuate__init(msg)
 #define nrm_msg_actuator_init(msg) nrm__actuator__init(msg)
 #define nrm_msg_actuatorlist_init(msg) nrm__actuator_list__init(msg)
 #define nrm_msg_add_init(msg) nrm__add__init(msg)
@@ -78,6 +81,7 @@ int nrm_msg_set_event(nrm_msg_t *msg,
                       nrm_uuid_t *uuid,
                       nrm_scope_t *scope,
                       double value);
+int nrm_msg_set_actuate(nrm_msg_t *msg, nrm_uuid_t *uuid, double value);
 int nrm_msg_set_add_actuator(nrm_msg_t *msg, nrm_actuator_t *actuator);
 int nrm_msg_set_add_scope(nrm_msg_t *msg, nrm_scope_t *scope);
 int nrm_msg_set_add_sensor(nrm_msg_t *msg, char *name, nrm_uuid_t *uuid);
@@ -115,6 +119,7 @@ nrm_msg_t *nrm_msg_recvfrom(zsock_t *socket, nrm_uuid_t **from);
 
 int nrm_msg_pub(zsock_t *socket, nrm_string_t topic, nrm_msg_t *msg);
 nrm_msg_t *nrm_msg_sub(zsock_t *socket, nrm_string_t *topic);
+
 /*******************************************************************************
  * Control Messages: mostly needed to exchange through shared memory between
  * various nrm layers (e.g. brokers and user-facing APIs)

--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -56,7 +56,7 @@ typedef Nrm__Slice nrm_msg_slice_t;
 typedef Nrm__SliceList nrm_msg_slicelist_t;
 
 #define nrm_msg_actuator_init(msg) nrm__actuator__init(msg)
-#define nrm_msg_actuatorlist_init(msg) nrm__actuatorlist__init(msg)
+#define nrm_msg_actuatorlist_init(msg) nrm__actuator_list__init(msg)
 #define nrm_msg_add_init(msg) nrm__add__init(msg)
 #define nrm_msg_event_init(msg) nrm__event__init(msg)
 #define nrm_msg_init(msg) nrm__message__init(msg)

--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -39,8 +39,11 @@ typedef enum _Nrm__TARGETTYPE nrm_msg_targettype_e;
 #define NRM_MSG_TARGET_TYPE_SLICE (NRM__TARGETTYPE__SLICE)
 #define NRM_MSG_TARGET_TYPE_SENSOR (NRM__TARGETTYPE__SENSOR)
 #define NRM_MSG_TARGET_TYPE_SCOPE (NRM__TARGETTYPE__SCOPE)
-#define NRM_MSG_TARGET_TYPE_MAX (3)
+#define NRM_MSG_TARGET_TYPE_ACTUATOR (NRM__TARGETTYPE__ACTUATOR)
+#define NRM_MSG_TARGET_TYPE_MAX (4)
 
+typedef Nrm__Actuator nrm_msg_actuator_t;
+typedef Nrm__ActuatorList nrm_msg_actuatorlist_t;
 typedef Nrm__Add nrm_msg_add_t;
 typedef Nrm__Event nrm_msg_event_t;
 typedef Nrm__List nrm_msg_list_t;
@@ -52,6 +55,8 @@ typedef Nrm__SensorList nrm_msg_sensorlist_t;
 typedef Nrm__Slice nrm_msg_slice_t;
 typedef Nrm__SliceList nrm_msg_slicelist_t;
 
+#define nrm_msg_actuator_init(msg) nrm__actuator__init(msg)
+#define nrm_msg_actuatorlist_init(msg) nrm__actuatorlist__init(msg)
 #define nrm_msg_add_init(msg) nrm__add__init(msg)
 #define nrm_msg_event_init(msg) nrm__event__init(msg)
 #define nrm_msg_init(msg) nrm__message__init(msg)
@@ -73,14 +78,17 @@ int nrm_msg_set_event(nrm_msg_t *msg,
                       nrm_uuid_t *uuid,
                       nrm_scope_t *scope,
                       double value);
+int nrm_msg_set_add_actuator(nrm_msg_t *msg, nrm_actuator_t *actuator);
 int nrm_msg_set_add_scope(nrm_msg_t *msg, nrm_scope_t *scope);
 int nrm_msg_set_add_sensor(nrm_msg_t *msg, char *name, nrm_uuid_t *uuid);
 int nrm_msg_set_add_slice(nrm_msg_t *msg, char *name, nrm_uuid_t *uuid);
+int nrm_msg_set_list_actuators(nrm_msg_t *msg, nrm_vector_t *actuators);
 int nrm_msg_set_list_scopes(nrm_msg_t *msg, nrm_vector_t *scopes);
 int nrm_msg_set_list_sensors(nrm_msg_t *msg, nrm_vector_t *sensors);
 int nrm_msg_set_list_slices(nrm_msg_t *msg, nrm_vector_t *slices);
 int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_uuid_t *uuid);
 
+nrm_actuator_t *nrm_actuator_create_frommsg(nrm_msg_actuator_t *msg);
 nrm_scope_t *nrm_scope_create_frommsg(nrm_msg_scope_t *msg);
 nrm_slice_t *nrm_slice_create_frommsg(nrm_msg_slice_t *msg);
 nrm_sensor_t *nrm_sensor_create_frommsg(nrm_msg_sensor_t *msg);

--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -91,6 +91,7 @@ int nrm_msg_set_list_scopes(nrm_msg_t *msg, nrm_vector_t *scopes);
 int nrm_msg_set_list_sensors(nrm_msg_t *msg, nrm_vector_t *sensors);
 int nrm_msg_set_list_slices(nrm_msg_t *msg, nrm_vector_t *slices);
 int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_uuid_t *uuid);
+int nrm_msg_is_reply(nrm_msg_t *msg);
 
 nrm_actuator_t *nrm_actuator_create_frommsg(nrm_msg_actuator_t *msg);
 nrm_scope_t *nrm_scope_create_frommsg(nrm_msg_scope_t *msg);

--- a/include/internal/nrmi.h
+++ b/include/internal/nrmi.h
@@ -87,12 +87,14 @@ struct nrm_scope {
 
 void nrm_log_printmsg(int level, nrm_msg_t *msg);
 
+int nrm_actuator_from_json(nrm_actuator_t *, json_t *);
 int nrm_bitmap_from_json(nrm_bitmap_t *, json_t *);
 int nrm_scope_from_json(nrm_scope_t *, json_t *);
 int nrm_sensor_from_json(nrm_sensor_t *, json_t *);
 int nrm_slice_from_json(nrm_slice_t *, json_t *);
 int nrm_time_from_json(nrm_time_t *, json_t *);
 
+json_t *nrm_actuator_to_json(nrm_actuator_t *);
 json_t *nrm_bitmap_to_json(nrm_bitmap_t *);
 json_t *nrm_uuid_to_json(nrm_uuid_t *);
 json_t *nrm_scope_to_json(nrm_scope_t *);

--- a/include/internal/roles.h
+++ b/include/internal/roles.h
@@ -36,6 +36,9 @@ struct nrm_role_ops {
 	                       nrm_role_sub_callback_fn *fn,
 	                       void *arg);
 	nrm_msg_t *(*sub)(const struct nrm_role_data *data, nrm_string_t topic);
+	int (*register_cmd_cb)(const struct nrm_role_data *data,
+	                       nrm_role_cmd_callback_fn *fn,
+	                       void *arg);
 	void (*destroy)(nrm_role_t **role);
 };
 

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -235,6 +235,7 @@ typedef int(nrm_client_event_listener_fn)(nrm_uuid_t *uuid,
                                           nrm_time_t time,
                                           nrm_scope_t *scope,
                                           double value);
+typedef int(nrm_client_actuate_listener_fn)(nrm_uuid_t *uuid, double value);
 
 /**
  * Creates a new NRM Client.
@@ -349,6 +350,10 @@ int nrm_client_set_event_listener(nrm_client_t *client,
 int nrm_client_start_event_listener(const nrm_client_t *client,
                                     nrm_string_t topic);
 
+int nrm_client_set_actuate_listener(nrm_client_t *client,
+                                    nrm_client_actuate_listener_fn fn);
+int nrm_client_start_actuate_listener(const nrm_client_t *client);
+
 /**
  * Removes an NRM client. Do this for each client before an instrumented program
  * exits.
@@ -366,6 +371,7 @@ void nrm_client_destroy(nrm_client_t **client);
 
 typedef struct nrm_role_s nrm_role_t;
 typedef int(nrm_role_sub_callback_fn)(nrm_msg_t *msg, void *arg);
+typedef int(nrm_role_cmd_callback_fn)(nrm_msg_t *msg, void *arg);
 
 nrm_role_t *nrm_role_monitor_create_fromenv();
 
@@ -378,6 +384,9 @@ nrm_msg_t *nrm_role_recv(const nrm_role_t *role, nrm_uuid_t **from);
 int nrm_role_pub(const nrm_role_t *role, nrm_string_t topic, nrm_msg_t *msg);
 int nrm_role_register_sub_cb(const nrm_role_t *role,
                              nrm_role_sub_callback_fn *fn,
+                             void *arg);
+int nrm_role_register_cmd_cb(const nrm_role_t *role,
+                             nrm_role_cmd_callback_fn *fn,
                              void *arg);
 int nrm_role_sub(const nrm_role_t *role, nrm_string_t topic);
 

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -132,7 +132,7 @@ struct nrm_actuator_s {
 
 typedef struct nrm_actuator_s nrm_actuator_t;
 
-nrm_actuator_t *nrm_actuator_create(char *name);
+nrm_actuator_t *nrm_actuator_create();
 
 void nrm_actuator_destroy(nrm_actuator_t **);
 void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);
@@ -196,6 +196,7 @@ void nrm_sensor_destroy(nrm_sensor_t **);
  ******************************************************************************/
 
 struct nrm_state_s {
+	nrm_vector_t *actuators;
 	nrm_vector_t *slices;
 	nrm_vector_t *sensors;
 	nrm_vector_t *scopes;

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -120,6 +120,24 @@ typedef struct _Nrm__Message nrm_msg_t;
 void nrm_msg_destroy(nrm_msg_t **msg);
 
 /*******************************************************************************
+ * Actuator: something capable of actions on the system
+ ******************************************************************************/
+
+struct nrm_actuator_s {
+	nrm_string_t name;
+	nrm_uuid_t *uuid;
+	double value;
+	nrm_vector_t *choices;
+};
+
+typedef struct nrm_actuator_s nrm_actuator_t;
+
+nrm_actuator_t *nrm_actuator_create(char *name);
+
+void nrm_actuator_destroy(nrm_actuator_t **);
+void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);
+
+/*******************************************************************************
  * Slice: a resource arbitration unit
  ******************************************************************************/
 

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -251,7 +251,8 @@ int nrm_client_create(nrm_client_t **client,
                       int pub_port,
                       int rpc_port);
 
-int nrm_client_add_actuator(const nrm_client_t *client, nrm_actuator_t *actuator);
+int nrm_client_add_actuator(const nrm_client_t *client,
+                            nrm_actuator_t *actuator);
 
 /**
  * Adds an NRM scope to an NRM client.
@@ -286,7 +287,8 @@ int nrm_client_find(const nrm_client_t *client,
                     nrm_uuid_t *uuid,
                     nrm_vector_t **results);
 
-int nrm_client_list_actuators(const nrm_client_t *client, nrm_vector_t **actuators);
+int nrm_client_list_actuators(const nrm_client_t *client,
+                              nrm_vector_t **actuators);
 
 /**
  * Lists an NRM client's registered scopes into a vector

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -250,6 +250,8 @@ int nrm_client_create(nrm_client_t **client,
                       int pub_port,
                       int rpc_port);
 
+int nrm_client_add_actuator(const nrm_client_t *client, nrm_actuator_t *actuator);
+
 /**
  * Adds an NRM scope to an NRM client.
  * @return 0 if successful, an error code otherwise
@@ -282,6 +284,8 @@ int nrm_client_find(const nrm_client_t *client,
                     char *name,
                     nrm_uuid_t *uuid,
                     nrm_vector_t **results);
+
+int nrm_client_list_actuators(const nrm_client_t *client, nrm_vector_t **actuators);
 
 /**
  * Lists an NRM client's registered scopes into a vector

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -126,6 +126,7 @@ void nrm_msg_destroy(nrm_msg_t **msg);
 struct nrm_actuator_s {
 	nrm_string_t name;
 	nrm_uuid_t *uuid;
+	nrm_uuid_t *clientid;
 	double value;
 	nrm_vector_t *choices;
 };

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -132,7 +132,7 @@ struct nrm_actuator_s {
 
 typedef struct nrm_actuator_s nrm_actuator_t;
 
-nrm_actuator_t *nrm_actuator_create();
+nrm_actuator_t *nrm_actuator_create(char *name);
 
 void nrm_actuator_destroy(nrm_actuator_t **);
 void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,12 @@ mkShell {
     python3
     llvmPackages.clang-unwrapped.python
     bear
-    protobufc
+    # docs
+    graphviz
+    doxygen
+    python3Packages.sphinx
+    python3Packages.breathe
+    python3Packages.sphinx_rtd_theme
   ];
 
   CFLAGS =

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the libnrm project.
+ * For more info, see https://github.com/anlsys/libnrm
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+#include "config.h"
+
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nrm.h"
+
+#include "internal/nrmi.h"
+
+nrm_actuator_t *nrm_actuator_create(char *name)
+{
+	nrm_actuator_t *ret = calloc(1, sizeof(nrm_actuator_t));
+	ret->name = nrm_string_fromchar(name);
+	ret->uuid = NULL;
+	return ret;
+}
+
+json_t *nrm_actuator_to_json(nrm_actuator_t *actuator)
+{
+	json_t *uuid = NULL;
+
+	if (actuator->uuid != NULL)
+		uuid = nrm_uuid_to_json(actuator->uuid);
+	return json_pack("{s:s, s:o*}", "name", actuator->name, "uuid", uuid);
+}
+
+void nrm_actuator_destroy(nrm_actuator_t **actuator)
+{
+	if (actuator == NULL || *actuator == NULL)
+		return;
+	nrm_string_decref(&(*actuator)->name);
+	nrm_uuid_destroy(&(*actuator)->uuid);
+	*actuator = NULL;
+}

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -83,23 +83,27 @@ int nrm_vector_d_from_json(nrm_vector_t *vector, json_t *json)
 json_t *nrm_actuator_to_json(nrm_actuator_t *actuator)
 {
 	json_t *uuid = NULL;
+	json_t *clientid = NULL;
 	json_t *choices = NULL;
 	if (actuator->uuid != NULL)
 		uuid = nrm_uuid_to_json(actuator->uuid);
+	if (actuator->clientid != NULL)
+		clientid = nrm_uuid_to_json(actuator->clientid);
 	choices = nrm_vector_d_to_json(actuator->choices);
-	return json_pack("{s:s, s:o?, s:f, s:o?}", "name", actuator->name, 
-			 "uuid", uuid, "value", actuator->value,
-			 "choices", choices);
+	return json_pack("{s:s, s:o?, s:o?, s:f, s:o?}", "name", actuator->name, 
+			 "uuid", uuid, "clientid", clientid, 
+			 "value", actuator->value, "choices", choices);
 }
 
 int nrm_actuator_from_json(nrm_actuator_t *actuator, json_t *json)
 {
 	json_t *choices = NULL;
 	char *uuid = NULL;
+	char *clientid = NULL;
 	json_error_t error;
 	int err;
-	err = json_unpack_ex(json, &error, 0, "{s?:s, s?:o, s?:f}",
-			     "uuid", &uuid, "choices", &choices,
+	err = json_unpack_ex(json, &error, 0, "{s?:s, s?:o, s?:o, s?:f}",
+			     "uuid", &uuid, "clientid", &clientid, "choices", &choices,
 			     "value", &actuator->value);
 	if (err) {
 		nrm_log_error("error unpacking json: %s, %s, %d, %d, %d\n",
@@ -109,6 +113,8 @@ int nrm_actuator_from_json(nrm_actuator_t *actuator, json_t *json)
 	}
 	if (uuid)
 		actuator->uuid = nrm_uuid_create_fromchar(uuid);
+	if (clientid)
+		actuator->clientid = nrm_uuid_create_fromchar(clientid);
 	nrm_vector_d_from_json(actuator->choices, choices);
 	return 0;
 }
@@ -119,6 +125,7 @@ void nrm_actuator_destroy(nrm_actuator_t **actuator)
 		return;
 	nrm_string_decref(&(*actuator)->name);
 	nrm_uuid_destroy(&(*actuator)->uuid);
+	nrm_uuid_destroy(&(*actuator)->clientid);
 	nrm_vector_destroy(&(*actuator)->choices);
 	*actuator = NULL;
 }

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -36,8 +36,9 @@ int nrm_actuator_set_value(nrm_actuator_t *actuator, double value)
 	return 0;
 }
 
-int nrm_actuator_set_choices(nrm_actuator_t *actuator, size_t nchoices, double
-			     *choices)
+int nrm_actuator_set_choices(nrm_actuator_t *actuator,
+                             size_t nchoices,
+                             double *choices)
 {
 	if (actuator == NULL || nchoices == 0 || choices == NULL)
 		return -NRM_EINVAL;
@@ -90,9 +91,9 @@ json_t *nrm_actuator_to_json(nrm_actuator_t *actuator)
 	if (actuator->clientid != NULL)
 		clientid = nrm_uuid_to_json(actuator->clientid);
 	choices = nrm_vector_d_to_json(actuator->choices);
-	return json_pack("{s:s, s:o?, s:o?, s:f, s:o?}", "name", actuator->name, 
-			 "uuid", uuid, "clientid", clientid, 
-			 "value", actuator->value, "choices", choices);
+	return json_pack("{s:s, s:o?, s:o?, s:f, s:o?}", "name", actuator->name,
+	                 "uuid", uuid, "clientid", clientid, "value",
+	                 actuator->value, "choices", choices);
 }
 
 int nrm_actuator_from_json(nrm_actuator_t *actuator, json_t *json)
@@ -103,8 +104,8 @@ int nrm_actuator_from_json(nrm_actuator_t *actuator, json_t *json)
 	json_error_t error;
 	int err;
 	err = json_unpack_ex(json, &error, 0, "{s?:s, s?:o, s?:o, s?:f}",
-			     "uuid", &uuid, "clientid", &clientid, "choices", &choices,
-			     "value", &actuator->value);
+	                     "uuid", &uuid, "clientid", &clientid, "choices",
+	                     &choices, "value", &actuator->value);
 	if (err) {
 		nrm_log_error("error unpacking json: %s, %s, %d, %d, %d\n",
 		              error.text, error.source, error.line,

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -24,16 +24,93 @@ nrm_actuator_t *nrm_actuator_create(char *name)
 	nrm_actuator_t *ret = calloc(1, sizeof(nrm_actuator_t));
 	ret->name = nrm_string_fromchar(name);
 	ret->uuid = NULL;
+	nrm_vector_create(&ret->choices, sizeof(double));
 	return ret;
+}
+
+int nrm_actuator_set_value(nrm_actuator_t *actuator, double value)
+{
+	if (actuator == NULL)
+		return -NRM_EINVAL;
+	actuator->value = value;
+	return 0;
+}
+
+int nrm_actuator_set_choices(nrm_actuator_t *actuator, size_t nchoices, double
+			     *choices)
+{
+	if (actuator == NULL || nchoices == 0 || choices == NULL)
+		return -NRM_EINVAL;
+	nrm_vector_resize(actuator->choices, nchoices);
+	for (size_t i = 0; i < nchoices; i++)
+		nrm_vector_push_back(actuator->choices, &choices[i]);
+	return 0;
+}
+
+json_t *nrm_vector_d_to_json(nrm_vector_t *vector)
+{
+	json_t *ret;
+	ret = json_array();
+	size_t nitems;
+	nrm_vector_length(vector, &nitems);
+	for (size_t i = 0; i < nitems; i++) {
+		double *d;
+		void *p;
+		nrm_vector_get(vector, i, &p);
+		d = (double *)p;
+		json_array_append_new(ret, json_real(*d));
+	}
+	return ret;
+}
+
+int nrm_vector_d_from_json(nrm_vector_t *vector, json_t *json)
+{
+	if (!json_is_array(json))
+		return -NRM_EINVAL;
+	size_t length = json_array_size(json);
+	nrm_vector_resize(vector, length);
+	nrm_vector_clear(vector);
+	size_t index;
+	json_t *value;
+	json_array_foreach(json, index, value)
+	{
+		double d = json_real_value(value);
+		nrm_vector_push_back(vector, &d);
+	}
+	return 0;
 }
 
 json_t *nrm_actuator_to_json(nrm_actuator_t *actuator)
 {
 	json_t *uuid = NULL;
-
+	json_t *choices = NULL;
 	if (actuator->uuid != NULL)
 		uuid = nrm_uuid_to_json(actuator->uuid);
-	return json_pack("{s:s, s:o*}", "name", actuator->name, "uuid", uuid);
+	choices = nrm_vector_d_to_json(actuator->choices);
+	return json_pack("{s:s, s:o?, s:f, s:o?}", "name", actuator->name, 
+			 "uuid", uuid, "value", actuator->value,
+			 "choices", choices);
+}
+
+int nrm_actuator_from_json(nrm_actuator_t *actuator, json_t *json)
+{
+	json_t *choices = NULL;
+	char *uuid = NULL;
+	json_error_t error;
+	int err;
+	err = json_unpack_ex(json, &error, 0, "{s?:s, s?:o, s?:f}",
+			     "uuid", &uuid, "choices", &choices,
+			     "value", &actuator->value);
+	if (err) {
+		nrm_log_error("error unpacking json: %s, %s, %d, %d, %d\n",
+		              error.text, error.source, error.line,
+		              error.column, error.position);
+		return -NRM_EINVAL;
+	}
+	if (uuid)
+		actuator->uuid = nrm_uuid_create_fromchar(uuid);
+	nrm_vector_d_from_json(actuator->choices, choices);
+	return 0;
 }
 
 void nrm_actuator_destroy(nrm_actuator_t **actuator)
@@ -42,5 +119,6 @@ void nrm_actuator_destroy(nrm_actuator_t **actuator)
 		return;
 	nrm_string_decref(&(*actuator)->name);
 	nrm_uuid_destroy(&(*actuator)->uuid);
+	nrm_vector_destroy(&(*actuator)->choices);
 	*actuator = NULL;
 }

--- a/src/actuator.c
+++ b/src/actuator.c
@@ -43,6 +43,7 @@ int nrm_actuator_set_choices(nrm_actuator_t *actuator,
 	if (actuator == NULL || nchoices == 0 || choices == NULL)
 		return -NRM_EINVAL;
 	nrm_vector_resize(actuator->choices, nchoices);
+	nrm_vector_clear(actuator->choices);
 	for (size_t i = 0; i < nchoices; i++)
 		nrm_vector_push_back(actuator->choices, &choices[i]);
 	return 0;

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -54,7 +54,7 @@ void print_version()
 
 int nrm_dummy_extra_callback(nrm_uuid_t *uuid, double value)
 {
-	nrm_log_debug("action %d\n", value);
+	nrm_log_debug("action %f\n", value);
 	return 0;
 }
 

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the libnrm project.
+ * For more info, see https://github.com/anlsys/libnrm
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "config.h"
+
+#include <getopt.h>
+
+#include "nrm.h"
+
+#include "internal/messages.h"
+#include "internal/nrmi.h"
+#include "internal/roles.h"
+
+static int ask_help = 0;
+static int ask_version = 0;
+static char *upstream_uri = NRM_DEFAULT_UPSTREAM_URI;
+static int pub_port = NRM_DEFAULT_UPSTREAM_PUB_PORT;
+static int rpc_port = NRM_DEFAULT_UPSTREAM_RPC_PORT;
+static nrm_client_t *client;
+
+static struct option long_options[] = {
+        {"help", no_argument, &ask_help, 1},
+        {"version", no_argument, &ask_version, 1},
+        {"uri", required_argument, NULL, 'u'},
+        {"rpc-port", required_argument, NULL, 'r'},
+        {"pub-port", required_argument, NULL, 'p'},
+        {0, 0, 0, 0},
+};
+
+static const char *short_options = "+hVu:r:p:";
+
+static const char *help[] = {"Usage: nrm-dummy-extra [options]\n\n",
+                             "Allowed options:\n",
+                             "--help, -h    : print this help message\n",
+                             "--version, -V : print program version\n", NULL};
+
+void print_help()
+{
+	for (int i = 0; help[i] != NULL; i++)
+		fprintf(stdout, "%s", help[i]);
+}
+
+void print_version()
+{
+	fprintf(stdout, "nrm-dummy-extra: version %s\n", nrm_version_string);
+}
+
+int nrm_dummy_extra_callback(nrm_uuid_t *uuid, double value)
+{
+	nrm_log_debug("action %d\n", value);
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int c;
+	int option_index = 0;
+
+	while (1) {
+		c = getopt_long(argc, argv, short_options, long_options,
+		                &option_index);
+		if (c == -1)
+			break;
+		switch (c) {
+		case 0:
+			break;
+		case 'h':
+			ask_help = 1;
+			break;
+		case 'p':
+			errno = 0;
+			pub_port = strtol(optarg, NULL, 0);
+			assert(errno == 0);
+			break;
+		case 'r':
+			errno = 0;
+			rpc_port = strtol(optarg, NULL, 0);
+			assert(errno == 0);
+			break;
+		case 'u':
+			upstream_uri = optarg;
+			break;
+		case 'V':
+			ask_version = 1;
+			break;
+		case ':':
+			fprintf(stderr, "nrm-dummy-extra: missing argument\n");
+			exit(EXIT_FAILURE);
+		case '?':
+			fprintf(stderr, "nrm-dummy-extra: invalid option: %s\n",
+			        argv[optind - 1]);
+			exit(EXIT_FAILURE);
+		default:
+			fprintf(stderr,
+			        "nrm-dummy-extra: this should not happen\n");
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	/* remove the parsed part */
+	argc -= optind;
+	argv = &(argv[optind]);
+
+	if (ask_help) {
+		print_help();
+		exit(EXIT_SUCCESS);
+	}
+	if (ask_version) {
+		print_version();
+		exit(EXIT_SUCCESS);
+	}
+
+	nrm_init(NULL, NULL);
+	nrm_log_init(stderr, "nrm-dummy-extra");
+	nrm_log_setlevel(NRM_LOG_DEBUG);
+
+	nrm_log_debug("after command line parsing: argc: %u argv[0]: %s\n",
+	              argc, argv[0]);
+
+	nrm_log_info("creating client\n");
+	nrm_client_create(&client, upstream_uri, pub_port, rpc_port);
+
+	nrm_sensor_t *sensor;
+	nrm_scope_t *scope;
+	nrm_actuator_t *actuator;
+	int err;
+
+	nrm_log_info("creating dummy sensor\n");
+	sensor = nrm_sensor_create("nrm-dummy-extra-sensor");
+	err = nrm_client_add_sensor(client, sensor);
+	if (err) {
+		nrm_log_error("error during client request\n");
+		return EXIT_FAILURE;
+	}
+
+	nrm_log_info("creating dummy scope\n");
+	scope = nrm_scope_create();
+	nrm_scope_threadprivate(scope);
+	err = nrm_client_add_scope(client, scope);
+	if (err) {
+		nrm_log_error("error during client request\n");
+		return EXIT_FAILURE;
+	}
+
+	nrm_log_info("creating dummy actuator\n");
+	actuator = nrm_actuator_create("nrm-dummy-extra-actuator");
+	double choices[2] = {0.0, 1.0};
+	nrm_actuator_set_choices(actuator, 2, choices);
+	nrm_actuator_set_value(actuator, 0.0);
+	err = nrm_client_add_actuator(client, actuator);
+	if (err) {
+		nrm_log_error("error during client request\n");
+		return EXIT_FAILURE;
+	}
+
+	nrm_log_info("starting dummy actuate callback\n");
+	nrm_client_set_actuate_listener(client, nrm_dummy_extra_callback);
+	nrm_client_start_actuate_listener(client);
+
+	uint64_t counter = 0;
+	while (true) {
+		nrm_time_t time;
+		nrm_time_gettime(&time);
+		nrm_client_send_event(client, time, sensor, scope, counter++);
+		sleep(1);
+	}
+
+	nrm_client_destroy(&client);
+	nrm_finalize();
+	return err;
+}

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -101,6 +101,27 @@ int cmd_run(int argc, char **argv)
 	return err;
 }
 
+int cmd_add_actuator(int argc, char **argv)
+{
+
+	/* no matter the arguments, only one extra parameter */
+	if (argc != 2)
+		return EXIT_FAILURE;
+
+	int err;
+	char *name = argv[1];
+	nrm_actuator_t *actuator = nrm_actuator_create(name);
+
+	err = nrm_client_add_actuator(client, actuator);
+	if (err) {
+		nrm_log_error("error during client request\n");
+		return EXIT_FAILURE;
+	}
+	json_t *json = nrm_actuator_to_json(actuator);
+	json_dumpf(json, stdout, JSON_SORT_KEYS);
+	return 0;
+}
+
 int cmd_add_scope(int argc, char **argv)
 {
 

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -134,34 +134,6 @@ int cmd_run(int argc, char **argv)
 	return err;
 }
 
-int cmd_add_actuator(int argc, char **argv)
-{
-
-	/* no matter the arguments, only one extra parameter */
-	if (argc != 3)
-		return EXIT_FAILURE;
-
-	int err;
-	char *name = argv[1];
-	nrm_actuator_t *actuator = nrm_actuator_create(name);
-
-	json_t *param;
-	json_error_t json_error;
-	param = json_loads(argv[2], 0, &json_error);
-	err = nrm_actuator_from_json(actuator, param);
-	if (err)
-		return EXIT_FAILURE;
-
-	err = nrm_client_add_actuator(client, actuator);
-	if (err) {
-		nrm_log_error("error during client request\n");
-		return EXIT_FAILURE;
-	}
-	json_t *json = nrm_actuator_to_json(actuator);
-	json_dumpf(json, stdout, JSON_SORT_KEYS);
-	return 0;
-}
-
 int cmd_add_scope(int argc, char **argv)
 {
 
@@ -656,82 +628,6 @@ int cmd_list_slices(int argc, char **argv)
 	return 0;
 }
 
-int cmd_remove_actuator(int argc, char **argv)
-{
-	int err;
-	static int ask_uuid = 0;
-	static int ask_all = 0;
-	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {"all", no_argument, &ask_uuid, 1},
-	        {0, 0, 0, 0},
-	};
-
-	static const char *cmd_run_short_options = ":ua";
-
-	int c;
-	int option_index = 0;
-	while (1) {
-		c = getopt_long(argc, argv, cmd_run_short_options,
-		                cmd_run_long_options, &option_index);
-		if (c == -1)
-			break;
-		switch (c) {
-		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
-			break;
-		case 'a':
-			ask_all = 1;
-			break;
-		case '?':
-			return EXIT_FAILURE;
-		default:
-			return EXIT_FAILURE;
-		}
-	}
-	/* remove the parsed part */
-	argc -= optind;
-	argv = &(argv[optind]);
-
-	if (argc < 1)
-		return EXIT_FAILURE;
-
-	nrm_vector_t *results;
-	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name, uuid,
-	                      &results);
-	if (err) {
-		nrm_log_error("error during client request\n");
-		return EXIT_FAILURE;
-	}
-
-	size_t len;
-	nrm_vector_length(results, &len);
-	/* either remove all, or just one (if we found one) */
-	len = ask_all ? len : len > 0 ? 1 : 0;
-
-	json_t *array = json_array();
-	for (size_t i = 0; i < len; i++) {
-		nrm_actuator_t *r;
-		void *p;
-		nrm_vector_get(results, i, &p);
-		r = (nrm_actuator_t *)p;
-		json_t *json = nrm_actuator_to_json(r);
-		nrm_client_remove(client, NRM_MSG_TARGET_TYPE_ACTUATOR,
-		                  r->uuid);
-		json_array_append_new(array, json);
-	}
-	json_dumpf(array, stdout, JSON_SORT_KEYS);
-	return 0;
-}
-
 int cmd_remove_scope(int argc, char **argv)
 {
 	int err;
@@ -996,7 +892,6 @@ int cmd_send_event(int argc, char **argv)
 
 static struct client_cmd commands[] = {
         {"actuate", cmd_actuate},
-        {"add-actuator", cmd_add_actuator},
         {"add-scope", cmd_add_scope},
         {"add-slice", cmd_add_slice},
         {"add-sensor", cmd_add_sensor},
@@ -1010,7 +905,6 @@ static struct client_cmd commands[] = {
         {"list-slices", cmd_list_slices},
         {"list-sensors", cmd_list_sensors},
         {"send-event", cmd_send_event},
-        {"remove-actuator", cmd_remove_actuator},
         {"remove-scope", cmd_remove_scope},
         {"remove-slice", cmd_remove_slice},
         {"remove-sensor", cmd_remove_sensor},

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -89,7 +89,6 @@ int cmd_actuate(int argc, char **argv)
 	return 0;
 }
 
-
 int cmd_run(int argc, char **argv)
 {
 
@@ -725,7 +724,8 @@ int cmd_remove_actuator(int argc, char **argv)
 		nrm_vector_get(results, i, &p);
 		r = (nrm_actuator_t *)p;
 		json_t *json = nrm_actuator_to_json(r);
-		nrm_client_remove(client, NRM_MSG_TARGET_TYPE_ACTUATOR, r->uuid);
+		nrm_client_remove(client, NRM_MSG_TARGET_TYPE_ACTUATOR,
+		                  r->uuid);
 		json_array_append_new(array, json);
 	}
 	json_dumpf(array, stdout, JSON_SORT_KEYS);

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -105,12 +105,19 @@ int cmd_add_actuator(int argc, char **argv)
 {
 
 	/* no matter the arguments, only one extra parameter */
-	if (argc != 2)
+	if (argc != 3)
 		return EXIT_FAILURE;
 
 	int err;
 	char *name = argv[1];
 	nrm_actuator_t *actuator = nrm_actuator_create(name);
+
+	json_t *param;
+	json_error_t json_error;
+	param = json_loads(argv[2], 0, &json_error);
+	err = nrm_actuator_from_json(actuator, param);
+	if (err)
+		return EXIT_FAILURE;
 
 	err = nrm_client_add_actuator(client, actuator);
 	if (err) {

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -56,6 +56,40 @@ struct client_cmd {
 	int (*fn)(int, char **);
 };
 
+int cmd_actuate(int argc, char **argv)
+{
+	/* no options at this time */
+	if (argc < 3)
+		return EXIT_FAILURE;
+
+	char *name = argv[1];
+	double value = strtod(argv[2], NULL);
+
+	/* find actuator */
+	int err;
+	nrm_vector_t *results;
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name, NULL,
+	                      &results);
+	if (err) {
+		nrm_log_error("error during client request\n");
+		return EXIT_FAILURE;
+	}
+
+	size_t len;
+	nrm_vector_length(results, &len);
+
+	assert(len == 1);
+	nrm_actuator_t *a;
+	void *p;
+	nrm_vector_get(results, 0, &p);
+	a = (nrm_actuator_t *)p;
+
+	nrm_log_info("sending actuation\n");
+	nrm_client_actuate(client, a, value);
+	return 0;
+}
+
+
 int cmd_run(int argc, char **argv)
 {
 
@@ -961,6 +995,7 @@ int cmd_send_event(int argc, char **argv)
 }
 
 static struct client_cmd commands[] = {
+        {"actuate", cmd_actuate},
         {"add-actuator", cmd_add_actuator},
         {"add-scope", cmd_add_scope},
         {"add-slice", cmd_add_slice},

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -133,11 +133,13 @@ nrm_msg_t *nrmd_daemon_build_list_slices()
 	return ret;
 }
 
-nrm_msg_t *nrmd_daemon_add_actuator(nrm_uuid_t *clientid, nrm_msg_actuator_t *actuator)
+nrm_msg_t *nrmd_daemon_add_actuator(nrm_uuid_t *clientid,
+                                    nrm_msg_actuator_t *actuator)
 {
 	nrm_actuator_t *newactuator = nrm_actuator_create_frommsg(actuator);
 	newactuator->uuid = nrm_uuid_create();
-	newactuator->clientid = nrm_uuid_create_fromchar(nrm_uuid_to_char(clientid));
+	newactuator->clientid =
+	        nrm_uuid_create_fromchar(nrm_uuid_to_char(clientid));
 	nrm_vector_push_back(my_daemon.state->actuators, newactuator);
 
 	nrm_msg_t *ret = nrm_msg_create();
@@ -292,7 +294,7 @@ nrm_msg_t *nrmd_handle_actuate_request(nrm_msg_actuate_t *msg)
 	nrm_actuator_t *actuator;
 	size_t len;
 	nrm_vector_length(my_daemon.state->actuators, &len);
-	for(size_t i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		void *p;
 		nrm_actuator_t *a;
 		nrm_vector_get(my_daemon.state->actuators, i, &p);
@@ -300,7 +302,7 @@ nrm_msg_t *nrmd_handle_actuate_request(nrm_msg_actuate_t *msg)
 		if (!nrm_uuid_cmp(a->uuid, uuid)) {
 			/* found the actuator */
 			nrm_log_debug("actuating %s: %f\n", *a->uuid,
-				      msg->value);
+			              msg->value);
 			break;
 		}
 	}

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -284,6 +284,30 @@ int nrmd_handle_event_request(nrm_msg_event_t *msg)
 	return 0;
 }
 
+nrm_msg_t *nrmd_handle_actuate_request(nrm_msg_actuate_t *msg)
+{
+	nrm_uuid_t *uuid = nrm_uuid_create_fromchar(msg->uuid);
+	/* find the actuator */
+	nrm_actuator_t *actuator;
+	size_t len;
+	nrm_vector_length(my_daemon.state->actuators, &len);
+	for(size_t i = 0; i < len; i++) {
+		void *p;
+		nrm_actuator_t *a;
+		nrm_vector_get(my_daemon.state->actuators, i, &p);
+		a = (nrm_actuator_t *)p;
+		if (!nrm_uuid_cmp(a->uuid, uuid)) {
+			/* found the actuator */
+			nrm_log_debug("actuating %s: %f\n", *a->uuid,
+				      msg->value);
+			break;
+		}
+	}
+	nrm_msg_t *ret = nrm_msg_create();
+	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
+	return ret;
+}
+
 int nrmd_shim_controller_read_callback(zloop_t *loop,
                                        zsock_t *socket,
                                        void *arg)
@@ -298,6 +322,10 @@ int nrmd_shim_controller_read_callback(zloop_t *loop,
 	msg = nrm_role_recv(self, &uuid);
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 	switch (msg->type) {
+	case NRM_MSG_TYPE_ACTUATE:
+		ret = nrmd_handle_actuate_request(msg->actuate);
+		nrm_role_send(self, ret, uuid);
+		break;
 	case NRM_MSG_TYPE_LIST:
 		ret = nrmd_handle_list_request(msg->list);
 		nrm_role_send(self, ret, uuid);

--- a/src/client.c
+++ b/src/client.c
@@ -64,7 +64,7 @@ int nrm_client_add_actuator(const nrm_client_t *client, nrm_actuator_t *actuator
 
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_ACTUATOR);
-	actuator = nrm_actuator_create_frommsg(msg->add->actuator);
+	nrm_actuator_update_frommsg(actuator, msg->add->actuator);
 	return 0;
 }
 

--- a/src/client.c
+++ b/src/client.c
@@ -42,8 +42,9 @@ int nrm_client_create(nrm_client_t **client,
 	return 0;
 }
 
-int nrm_client_actuate(const nrm_client_t *client, nrm_actuator_t *actuator,
-		       double value)
+int nrm_client_actuate(const nrm_client_t *client,
+                       nrm_actuator_t *actuator,
+                       double value)
 {
 	if (client == NULL || actuator == NULL)
 		return -NRM_EINVAL;
@@ -83,7 +84,8 @@ int nrm_client_actuate(const nrm_client_t *client, nrm_actuator_t *actuator,
 	return 0;
 }
 
-int nrm_client_add_actuator(const nrm_client_t *client, nrm_actuator_t *actuator)
+int nrm_client_add_actuator(const nrm_client_t *client,
+                            nrm_actuator_t *actuator)
 {
 	if (client == NULL || actuator == NULL)
 		return -NRM_EINVAL;
@@ -209,22 +211,22 @@ int nrm_client_find(const nrm_client_t *client,
 	nrm_log_debug("crafting message\n");
 	nrm_msg_t *msg = nrm_msg_create();
 	nrm_msg_fill(msg, NRM_MSG_TYPE_LIST);
-	switch(type) {
-		case NRM_MSG_TARGET_TYPE_ACTUATOR:
-			nrm_msg_set_list_actuators(msg, NULL);
-			break;
-		case NRM_MSG_TARGET_TYPE_SCOPE:
-			nrm_msg_set_list_scopes(msg, NULL);
-			break;
-		case NRM_MSG_TARGET_TYPE_SENSOR:
-			nrm_msg_set_list_sensors(msg, NULL);
-			break;
-		case NRM_MSG_TARGET_TYPE_SLICE:
-			nrm_msg_set_list_slices(msg, NULL);
-			break;
-		default:
-			nrm_log_error("missing case for type %d\n", type);
-			assert(0);
+	switch (type) {
+	case NRM_MSG_TARGET_TYPE_ACTUATOR:
+		nrm_msg_set_list_actuators(msg, NULL);
+		break;
+	case NRM_MSG_TARGET_TYPE_SCOPE:
+		nrm_msg_set_list_scopes(msg, NULL);
+		break;
+	case NRM_MSG_TARGET_TYPE_SENSOR:
+		nrm_msg_set_list_sensors(msg, NULL);
+		break;
+	case NRM_MSG_TARGET_TYPE_SLICE:
+		nrm_msg_set_list_slices(msg, NULL);
+		break;
+	default:
+		nrm_log_error("missing case for type %d\n", type);
+		assert(0);
 	}
 	assert(msg->type == NRM_MSG_TYPE_LIST);
 	assert(msg->list->type == type);
@@ -248,7 +250,8 @@ int nrm_client_find(const nrm_client_t *client,
 
 		for (size_t i = 0; i < msg->list->actuators->n_actuators; i++) {
 			if (uuid != NULL &&
-			    strcmp(*uuid, msg->list->actuators->actuators[i]->uuid))
+			    strcmp(*uuid,
+			           msg->list->actuators->actuators[i]->uuid))
 				continue;
 			nrm_actuator_t *s = nrm_actuator_create_frommsg(
 			        msg->list->actuators->actuators[i]);
@@ -335,7 +338,8 @@ int nrm_client_start_event_listener(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_list_actuators(const nrm_client_t *client, nrm_vector_t **actuators)
+int nrm_client_list_actuators(const nrm_client_t *client,
+                              nrm_vector_t **actuators)
 {
 	if (client == NULL || actuators == NULL)
 		return -NRM_EINVAL;
@@ -364,8 +368,8 @@ int nrm_client_list_actuators(const nrm_client_t *client, nrm_vector_t **actuato
 	assert(msg->type == NRM_MSG_TYPE_LIST);
 	assert(msg->list->type == NRM_MSG_TARGET_TYPE_ACTUATOR);
 	for (size_t i = 0; i < msg->list->actuators->n_actuators; i++) {
-		nrm_actuator_t *s =
-		        nrm_actuator_create_frommsg(msg->list->actuators->actuators[i]);
+		nrm_actuator_t *s = nrm_actuator_create_frommsg(
+		        msg->list->actuators->actuators[i]);
 		nrm_vector_push_back(ret, s);
 	}
 	*actuators = ret;

--- a/src/client.c
+++ b/src/client.c
@@ -42,6 +42,32 @@ int nrm_client_create(nrm_client_t **client,
 	return 0;
 }
 
+int nrm_client_add_actuator(const nrm_client_t *client, nrm_actuator_t *actuator)
+{
+	if (client == NULL || actuator == NULL)
+		return -NRM_EINVAL;
+
+	nrm_log_debug("crafting message\n");
+	/* craft the message we want to send */
+	nrm_msg_t *msg = nrm_msg_create();
+	nrm_msg_fill(msg, NRM_MSG_TYPE_ADD);
+	nrm_msg_set_add_actuator(msg, actuator);
+	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
+	nrm_log_debug("sending request\n");
+	nrm_role_send(client->role, msg, NULL);
+
+	/* wait for the answer */
+	nrm_log_debug("receiving reply\n");
+	msg = nrm_role_recv(client->role, NULL);
+	nrm_log_debug("parsing reply:\t");
+	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
+
+	assert(msg->type == NRM_MSG_TYPE_ADD);
+	assert(msg->add->type == NRM_MSG_TARGET_TYPE_ACTUATOR);
+	actuator = nrm_actuator_create_frommsg(msg->add->actuator);
+	return 0;
+}
+
 int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope)
 {
 	if (client == NULL || scope == NULL)

--- a/src/messages.c
+++ b/src/messages.c
@@ -107,7 +107,8 @@ nrm_msg_actuator_t *nrm_msg_actuator_new(nrm_actuator_t *actuator)
 	ret->choices = calloc(ret->n_choices, sizeof(double));
 	assert(ret->choices);
 	for (size_t i = 0; i < ret->n_choices; i++) {
-		void *p; double *d;
+		void *p;
+		double *d;
 		nrm_vector_get(actuator->choices, i, &p);
 		d = (double *)p;
 		ret->choices[i] = *d;
@@ -406,7 +407,7 @@ nrm_actuator_t *nrm_actuator_create_frommsg(nrm_msg_actuator_t *msg)
 	ret->value = msg->value;
 	nrm_vector_resize(ret->choices, msg->n_choices);
 	nrm_vector_clear(ret->choices);
-	for(size_t i = 0; i < msg->n_choices; i++)
+	for (size_t i = 0; i < msg->n_choices; i++)
 		nrm_vector_push_back(ret->choices, &msg->choices[i]);
 	return ret;
 }
@@ -445,7 +446,8 @@ nrm_slice_t *nrm_slice_create_frommsg(nrm_msg_slice_t *msg)
 	return ret;
 }
 
-int nrm_actuator_update_frommsg(nrm_actuator_t *actuator, nrm_msg_actuator_t *msg)
+int nrm_actuator_update_frommsg(nrm_actuator_t *actuator,
+                                nrm_msg_actuator_t *msg)
 {
 	if (actuator == NULL || msg == NULL)
 		return -NRM_EINVAL;
@@ -461,7 +463,7 @@ int nrm_actuator_update_frommsg(nrm_actuator_t *actuator, nrm_msg_actuator_t *ms
 	nrm_vector_create(&actuator->choices, sizeof(double));
 	nrm_vector_resize(actuator->choices, msg->n_choices);
 	nrm_vector_clear(actuator->choices);
-	for(size_t i = 0; i < msg->n_choices; i++)
+	for (size_t i = 0; i < msg->n_choices; i++)
 		nrm_vector_push_back(actuator->choices, &msg->choices[i]);
 	return 0;
 }
@@ -642,12 +644,12 @@ typedef struct nrm_msg_type_table_s nrm_msg_type_table_t;
 
 static const nrm_msg_type_table_t nrm_msg_type_table[] = {
         {NRM_MSG_TYPE_ACK, "ACK"},
-	{NRM_MSG_TYPE_LIST, "LIST"},
+        {NRM_MSG_TYPE_LIST, "LIST"},
         {NRM_MSG_TYPE_ADD, "ADD"},
-	{NRM_MSG_TYPE_REMOVE, "REMOVE"},
+        {NRM_MSG_TYPE_REMOVE, "REMOVE"},
         {NRM_MSG_TYPE_EVENT, "EVENT"},
         {NRM_MSG_TYPE_ACTUATE, "ACTUATE"},
-	{0, NULL},
+        {0, NULL},
 };
 
 static const nrm_msg_type_table_t nrm_msg_target_table[] = {
@@ -692,9 +694,8 @@ json_t *nrm_msg_actuator_to_json(nrm_msg_actuator_t *msg)
 	json_t *choices;
 	choices = nrm_msg_darray_to_json(msg->n_choices, msg->choices);
 	ret = json_pack("{s:s, s:s?, s:s?, s:o, s:o}", "name", msg->name,
-			"uuid", msg->uuid, "clientid", msg->clientid,
-			"value", json_real(msg->value),
-			"choices", choices);
+	                "uuid", msg->uuid, "clientid", msg->clientid, "value",
+	                json_real(msg->value), "choices", choices);
 	return ret;
 }
 
@@ -703,8 +704,8 @@ json_t *nrm_msg_actuatorlist_to_json(nrm_msg_actuatorlist_t *msg)
 	json_t *ret;
 	ret = json_array();
 	for (size_t i = 0; i < msg->n_actuators; i++) {
-		json_array_append_new(ret,
-		                      nrm_msg_actuator_to_json(msg->actuators[i]));
+		json_array_append_new(
+		        ret, nrm_msg_actuator_to_json(msg->actuators[i]));
 	}
 	return ret;
 }

--- a/src/messages.c
+++ b/src/messages.c
@@ -99,7 +99,9 @@ nrm_msg_actuator_t *nrm_msg_actuator_new(nrm_actuator_t *actuator)
 	nrm_msg_actuator_init(ret);
 	ret->name = strdup(actuator->name);
 	if (actuator->uuid)
-		ret->uuid = strdup((char *)nrm_uuid_to_char(actuator->uuid));
+		ret->uuid = strdup(nrm_uuid_to_char(actuator->uuid));
+	if (actuator->clientid)
+		ret->clientid = strdup(nrm_uuid_to_char(actuator->clientid));
 	ret->value = actuator->value;
 	nrm_vector_length(actuator->choices, &ret->n_choices);
 	ret->choices = calloc(ret->n_choices, sizeof(double));
@@ -120,7 +122,7 @@ nrm_msg_scope_t *nrm_msg_scope_new(nrm_scope_t *scope)
 		return NULL;
 	nrm_msg_scope_init(ret);
 	if (scope->uuid)
-		ret->uuid = strdup((char *)nrm_uuid_to_char(scope->uuid));
+		ret->uuid = strdup(nrm_uuid_to_char(scope->uuid));
 	nrm_bitmap_to_array(&scope->maps[NRM_SCOPE_TYPE_CPU], &ret->n_cpus,
 	                    &ret->cpus);
 	nrm_bitmap_to_array(&scope->maps[NRM_SCOPE_TYPE_NUMA], &ret->n_numas,
@@ -399,6 +401,8 @@ nrm_actuator_t *nrm_actuator_create_frommsg(nrm_msg_actuator_t *msg)
 	nrm_actuator_t *ret = nrm_actuator_create(msg->name);
 	if (msg->uuid)
 		ret->uuid = nrm_uuid_create_fromchar(msg->uuid);
+	if (msg->clientid)
+		ret->clientid = nrm_uuid_create_fromchar(msg->uuid);
 	ret->value = msg->value;
 	nrm_vector_resize(ret->choices, msg->n_choices);
 	nrm_vector_clear(ret->choices);
@@ -449,6 +453,8 @@ int nrm_actuator_update_frommsg(nrm_actuator_t *actuator, nrm_msg_actuator_t *ms
 	actuator->name = nrm_string_fromchar(msg->name);
 	if (msg->uuid)
 		actuator->uuid = nrm_uuid_create_fromchar(msg->uuid);
+	if (msg->clientid)
+		actuator->clientid = nrm_uuid_create_fromchar(msg->clientid);
 	actuator->value = msg->value;
 	if (actuator->choices)
 		nrm_vector_destroy(&actuator->choices);
@@ -685,8 +691,9 @@ json_t *nrm_msg_actuator_to_json(nrm_msg_actuator_t *msg)
 	json_t *ret;
 	json_t *choices;
 	choices = nrm_msg_darray_to_json(msg->n_choices, msg->choices);
-	ret = json_pack("{s:s, s:s?, s:o, s:o}", "name", msg->name,
-			"uuid", msg->uuid, "value", json_real(msg->value),
+	ret = json_pack("{s:s, s:s?, s:s?, s:o, s:o}", "name", msg->name,
+			"uuid", msg->uuid, "clientid", msg->clientid,
+			"value", json_real(msg->value),
 			"choices", choices);
 	return ret;
 }

--- a/src/messages.c
+++ b/src/messages.c
@@ -419,6 +419,20 @@ nrm_slice_t *nrm_slice_create_frommsg(nrm_msg_slice_t *msg)
 	return ret;
 }
 
+int nrm_actuator_update_frommsg(nrm_actuator_t *actuator, nrm_msg_actuator_t *msg)
+{
+	if (actuator == NULL || msg == NULL)
+		return -NRM_EINVAL;
+
+	actuator->name = nrm_string_fromchar(msg->name);
+	if (msg->uuid)
+		actuator->uuid = nrm_uuid_create_fromchar(msg->uuid);
+	actuator->value = msg->value;
+	actuator->choices = realloc(actuator->choices, msg->n_choices*sizeof(double));
+	memcpy(actuator->choices, msg->choices, msg->n_choices * sizeof(double));
+	return 0;
+}
+
 int nrm_scope_update_frommsg(nrm_scope_t *scope, nrm_msg_scope_t *msg)
 {
 	if (scope == NULL || msg == NULL)

--- a/src/messages.c
+++ b/src/messages.c
@@ -889,6 +889,17 @@ int nrm_msg_fprintf(FILE *f, nrm_msg_t *msg)
 	return 0;
 }
 
+int nrm_msg_is_reply(nrm_msg_t *msg)
+{
+	switch (msg->type) {
+	case NRM_MSG_TYPE_ACTUATE:
+		return 0;
+	default:
+		return 1;
+	}
+	return 0;
+}
+
 /*******************************************************************************
  * Broker Communication
  *******************************************************************************/

--- a/src/msg.proto
+++ b/src/msg.proto
@@ -5,6 +5,7 @@ enum TARGETTYPE {
 	SLICE = 0;
 	SENSOR = 1;
 	SCOPE = 2;
+	ACTUATOR = 3;
 }
 
 enum MSGTYPE {
@@ -39,6 +40,13 @@ message Slice {
 	string uuid = 2;
 }
 
+message Actuator {
+	string name = 1;
+	string uuid = 2;
+	double value = 3;
+	repeated double choices = 4;
+}
+
 message ScopeList {
 	repeated Scope scopes = 1;
 }
@@ -49,6 +57,10 @@ message SensorList {
 
 message SliceList {
 	repeated Slice slices = 1;
+}
+
+message ActuatorList {
+	repeated Actuator actuators = 1;
 }
 
 message Remove {
@@ -62,6 +74,7 @@ message Add {
 		Slice slice = 2;
 		Sensor sensor = 3;
 		Scope scope = 4;
+		Actuator actuator = 5;
 	}
 }
 
@@ -71,6 +84,7 @@ message List {
 		SliceList slices = 2;
 		SensorList sensors = 3;
 		ScopeList scopes = 4;
+		ActuatorList actuators = 5;
 	}
 }
 

--- a/src/msg.proto
+++ b/src/msg.proto
@@ -14,6 +14,7 @@ enum MSGTYPE {
 	ADD = 2;
 	REMOVE = 3;
 	EVENT = 4;
+	ACTUATE = 5;
 }
 
 message Scope {
@@ -88,6 +89,11 @@ message List {
 	}
 }
 
+message Actuate {
+	string uuid = 1;
+	double value = 2;
+}
+
 message Message {
 	MSGTYPE type = 1;
 	oneof data {
@@ -95,5 +101,6 @@ message Message {
 		Add add = 3;
 		Remove remove = 4;
 		Event event = 5;
+		Actuate actuate = 6;
 	}
 }

--- a/src/msg.proto
+++ b/src/msg.proto
@@ -44,8 +44,9 @@ message Slice {
 message Actuator {
 	string name = 1;
 	string uuid = 2;
-	double value = 3;
-	repeated double choices = 4;
+	string clientid = 3;
+	double value = 4;
+	repeated double choices = 5;
 }
 
 message ScopeList {

--- a/src/roles/controller.c
+++ b/src/roles/controller.c
@@ -75,8 +75,8 @@ int nrm_controller_broker_pipe_handler(zloop_t *loop,
 		/* returning -1 exits the loop */
 		return -1;
 	case NRM_CTRLMSG_TYPE_SEND:
-		nrm_log_info("received request to send to client\n");
 		NRM_CTRLMSG_2SENDTO(p, q, msg, uuid);
+		nrm_log_info("received request to send to client: %s\n", *uuid);
 		nrm_msg_sendto(self->rpc, msg, uuid);
 		break;
 	case NRM_CTRLMSG_TYPE_PUB:

--- a/src/roles/controller.c
+++ b/src/roles/controller.c
@@ -242,5 +242,6 @@ struct nrm_role_ops nrm_role_controller_ops = {
         nrm_role_controller_pub,
         NULL,
         NULL,
+        NULL,
         nrm_role_controller_destroy,
 };

--- a/src/roles/role.c
+++ b/src/roles/role.c
@@ -44,6 +44,16 @@ int nrm_role_register_sub_cb(const nrm_role_t *role,
 	return role->ops->register_sub_cb(role->data, fn, arg);
 }
 
+int nrm_role_register_cmd_cb(const nrm_role_t *role,
+                             nrm_role_cmd_callback_fn *fn,
+                             void *arg)
+{
+	if (role == NULL || role->ops == NULL ||
+	    role->ops->register_cmd_cb == NULL)
+		return -NRM_ENOTSUP;
+	return role->ops->register_cmd_cb(role->data, fn, arg);
+}
+
 int nrm_role_sub(const nrm_role_t *role, nrm_string_t topic)
 {
 	if (role == NULL || role->ops == NULL || role->ops->sub == NULL)

--- a/src/state.c
+++ b/src/state.c
@@ -22,6 +22,7 @@
 nrm_state_t *nrm_state_create()
 {
 	nrm_state_t *ret = calloc(1, sizeof(nrm_state_t));
+	nrm_vector_create(&ret->actuators, sizeof(nrm_actuator_t));
 	nrm_vector_create(&ret->slices, sizeof(nrm_slice_t));
 	nrm_vector_create(&ret->sensors, sizeof(nrm_sensor_t));
 	nrm_vector_create(&ret->scopes, sizeof(nrm_scope_t));
@@ -33,6 +34,7 @@ void nrm_state_destroy(nrm_state_t **state)
 	if (state == NULL || *state == NULL)
 		return;
 	nrm_state_t *s = *state;
+	nrm_vector_destroy(&s->actuators);
 	nrm_vector_destroy(&s->slices);
 	nrm_vector_destroy(&s->sensors);
 	nrm_vector_destroy(&s->scopes);


### PR DESCRIPTION
Reintroduce actuators into the architecture.

They are identified by uuid, have a number of possible
actions, and are tracking a  network client id.

Note: this design assumes that any existing actuator has
been registered by the `nrm_client_t` providing it, so the
daemon tracks which client to send the action to this way.