### PR TITLE
[feature] remove names from nrm objects

### DIFF
--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -78,19 +78,18 @@ void nrm_msg_destroy(nrm_msg_t **msg);
 int nrm_msg_fill(nrm_msg_t *msg, int type);
 int nrm_msg_set_event(nrm_msg_t *msg,
                       nrm_time_t time,
-                      nrm_uuid_t *uuid,
+                      nrm_string_t sensor_uuid,
                       nrm_scope_t *scope,
                       double value);
-int nrm_msg_set_actuate(nrm_msg_t *msg, nrm_uuid_t *uuid, double value);
+int nrm_msg_set_actuate(nrm_msg_t *msg, nrm_string_t uuid, double value);
 int nrm_msg_set_add_actuator(nrm_msg_t *msg, nrm_actuator_t *actuator);
 int nrm_msg_set_add_scope(nrm_msg_t *msg, nrm_scope_t *scope);
-int nrm_msg_set_add_sensor(nrm_msg_t *msg, char *name, nrm_uuid_t *uuid);
-int nrm_msg_set_add_slice(nrm_msg_t *msg, char *name, nrm_uuid_t *uuid);
-int nrm_msg_set_list_actuators(nrm_msg_t *msg, nrm_vector_t *actuators);
+int nrm_msg_set_add_sensor(nrm_msg_t *msg, nrm_sensor_t *sensor);
+int nrm_msg_set_add_slice(nrm_msg_t *msg, nrm_slice_t *slice);
 int nrm_msg_set_list_scopes(nrm_msg_t *msg, nrm_vector_t *scopes);
 int nrm_msg_set_list_sensors(nrm_msg_t *msg, nrm_vector_t *sensors);
 int nrm_msg_set_list_slices(nrm_msg_t *msg, nrm_vector_t *slices);
-int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_uuid_t *uuid);
+int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_string_t uuid);
 int nrm_msg_is_reply(nrm_msg_t *msg);
 
 nrm_actuator_t *nrm_actuator_create_frommsg(nrm_msg_actuator_t *msg);

--- a/include/internal/nrmi.h
+++ b/include/internal/nrmi.h
@@ -81,7 +81,7 @@ int nrm_net_bind_2(zsock_t *socket, const char *uri, int port);
  ******************************************************************************/
 
 struct nrm_scope {
-	nrm_uuid_t *uuid;
+	nrm_string_t uuid;
 	struct nrm_bitmap maps[NRM_SCOPE_TYPE_MAX];
 };
 

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -124,8 +124,7 @@ void nrm_msg_destroy(nrm_msg_t **msg);
  ******************************************************************************/
 
 struct nrm_actuator_s {
-	nrm_string_t name;
-	nrm_uuid_t *uuid;
+	nrm_string_t uuid;
 	nrm_uuid_t *clientid;
 	double value;
 	nrm_vector_t *choices;
@@ -133,7 +132,7 @@ struct nrm_actuator_s {
 
 typedef struct nrm_actuator_s nrm_actuator_t;
 
-nrm_actuator_t *nrm_actuator_create(char *name);
+nrm_actuator_t *nrm_actuator_create(const char *name);
 
 void nrm_actuator_destroy(nrm_actuator_t **);
 void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);
@@ -143,8 +142,7 @@ void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);
  ******************************************************************************/
 
 struct nrm_slice_s {
-	nrm_string_t name;
-	nrm_uuid_t *uuid;
+	nrm_string_t uuid;
 };
 
 typedef struct nrm_slice_s nrm_slice_t;
@@ -155,7 +153,7 @@ typedef struct nrm_slice_s nrm_slice_t;
  * @param name: char pointer to a name describing the slice
  * @return: a new NRM slice structure
  */
-nrm_slice_t *nrm_slice_create(char *name);
+nrm_slice_t *nrm_slice_create(const char *name);
 
 /**
  * Removes an NRM slice. Do this for each slice before an instrumented program
@@ -173,8 +171,7 @@ void nrm_slice_fprintf(FILE *out, nrm_slice_t *);
  ******************************************************************************/
 
 struct nrm_sensor_s {
-	nrm_string_t name;
-	nrm_uuid_t *uuid;
+	nrm_string_t uuid;
 };
 
 typedef struct nrm_sensor_s nrm_sensor_t;
@@ -184,7 +181,7 @@ typedef struct nrm_sensor_s nrm_sensor_t;
  * @param name: char pointer to a name describing the sensor
  * @return: a new NRM sensor structure
  */
-nrm_sensor_t *nrm_sensor_create(char *name);
+nrm_sensor_t *nrm_sensor_create(const char *name);
 
 /**
  * Removes an NRM sensor. Do this for each sensor before an instrumented program
@@ -218,7 +215,7 @@ typedef struct nrm_eventbase_s nrm_eventbase_t;
 nrm_eventbase_t *nrm_eventbase_create(size_t maxperiods);
 
 int nrm_eventbase_push_event(
-        nrm_eventbase_t *, nrm_uuid_t *, nrm_scope_t *, nrm_time_t, double);
+        nrm_eventbase_t *, nrm_string_t, nrm_scope_t *, nrm_time_t, double);
 
 void nrm_eventbase_destroy(nrm_eventbase_t **);
 
@@ -231,7 +228,7 @@ void nrm_eventbase_destroy(nrm_eventbase_t **);
 
 typedef struct nrm_client_s nrm_client_t;
 
-typedef int(nrm_client_event_listener_fn)(nrm_uuid_t *uuid,
+typedef int(nrm_client_event_listener_fn)(nrm_string_t sensor_uuid,
                                           nrm_time_t time,
                                           nrm_scope_t *scope,
                                           double value);
@@ -251,6 +248,10 @@ int nrm_client_create(nrm_client_t **client,
                       const char *uri,
                       int pub_port,
                       int rpc_port);
+
+int nrm_client_actuate(const nrm_client_t *client,
+                       nrm_actuator_t *actuator,
+                       double value);
 
 int nrm_client_add_actuator(const nrm_client_t *client,
                             nrm_actuator_t *actuator);
@@ -277,15 +278,13 @@ int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice);
  * Find matching NRM objects within a client
  * @param client: NRM client
  * @param type: An NRM scope, sensor, or slice type
- * @param name: A sensor or type name?
- * @param uuid: A sensor uuid
+ * @param uuid: name/uuid of the object to find
  * @param results: NRM vector for containing results
  * @return 0 if successful, an error code otherwise
  */
 int nrm_client_find(const nrm_client_t *client,
                     int type,
-                    char *name,
-                    nrm_uuid_t *uuid,
+                    const char *uuid,
                     nrm_vector_t **results);
 
 int nrm_client_list_actuators(const nrm_client_t *client,
@@ -313,7 +312,7 @@ int nrm_client_list_slices(const nrm_client_t *client, nrm_vector_t **slices);
  * Removes an NRM slice from a client
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove(const nrm_client_t *client, int type, nrm_uuid_t *uuid);
+int nrm_client_remove(const nrm_client_t *client, int type, nrm_string_t uuid);
 
 /**
  * Sends a measurement to the NRM daemon

--- a/include/nrm/utils/strings.h
+++ b/include/nrm/utils/strings.h
@@ -16,9 +16,9 @@ typedef char *nrm_string_t;
 nrm_string_t nrm_string_fromchar(const char *buf);
 nrm_string_t nrm_string_frombuf(const char *buf, size_t len);
 
-void nrm_string_incref(nrm_string_t *s);
+void nrm_string_incref(nrm_string_t s);
 
-void nrm_string_decref(nrm_string_t *s);
+void nrm_string_decref(nrm_string_t s);
 
 int nrm_string_cmp(const nrm_string_t, const nrm_string_t);
 

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -68,7 +68,7 @@ int cmd_actuate(int argc, char **argv)
 	/* find actuator */
 	int err;
 	nrm_vector_t *results;
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name, NULL,
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -204,49 +204,14 @@ int cmd_add_sensor(int argc, char **argv)
 int cmd_find_actuator(int argc, char **argv)
 {
 
-	int err;
-	static int ask_uuid = 0;
-	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {0, 0, 0, 0},
-	};
-
-	static const char *cmd_run_short_options = ":u";
-
-	int c;
-	int option_index = 0;
-	while (1) {
-		c = getopt_long(argc, argv, cmd_run_short_options,
-		                cmd_run_long_options, &option_index);
-		if (c == -1)
-			break;
-		switch (c) {
-		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
-			break;
-		case '?':
-			return EXIT_FAILURE;
-		default:
-			return EXIT_FAILURE;
-		}
-	}
-	/* remove the parsed part */
-	argc -= optind;
-	argv = &(argv[optind]);
-
-	if (argc < 1)
+	if (argc < 2)
 		return EXIT_FAILURE;
 
+	int err;
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name, uuid,
+	name = argv[1];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_ACTUATOR, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -272,49 +237,14 @@ int cmd_find_actuator(int argc, char **argv)
 int cmd_find_scope(int argc, char **argv)
 {
 
-	int err;
-	static int ask_uuid = 0;
-	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {0, 0, 0, 0},
-	};
-
-	static const char *cmd_run_short_options = ":u";
-
-	int c;
-	int option_index = 0;
-	while (1) {
-		c = getopt_long(argc, argv, cmd_run_short_options,
-		                cmd_run_long_options, &option_index);
-		if (c == -1)
-			break;
-		switch (c) {
-		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
-			break;
-		case '?':
-			return EXIT_FAILURE;
-		default:
-			return EXIT_FAILURE;
-		}
-	}
-	/* remove the parsed part */
-	argc -= optind;
-	argv = &(argv[optind]);
-
-	if (argc < 1)
+	if (argc < 2)
 		return EXIT_FAILURE;
 
+	int err;
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SCOPE, name, uuid,
+	name = argv[1];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SCOPE, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -340,49 +270,14 @@ int cmd_find_scope(int argc, char **argv)
 int cmd_find_sensor(int argc, char **argv)
 {
 
-	int err;
-	static int ask_uuid = 0;
-	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {0, 0, 0, 0},
-	};
-
-	static const char *cmd_run_short_options = ":u";
-
-	int c;
-	int option_index = 0;
-	while (1) {
-		c = getopt_long(argc, argv, cmd_run_short_options,
-		                cmd_run_long_options, &option_index);
-		if (c == -1)
-			break;
-		switch (c) {
-		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
-			break;
-		case '?':
-			return EXIT_FAILURE;
-		default:
-			return EXIT_FAILURE;
-		}
-	}
-	/* remove the parsed part */
-	argc -= optind;
-	argv = &(argv[optind]);
-
-	if (argc < 1)
+	if (argc < 2)
 		return EXIT_FAILURE;
 
+	int err;
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name, uuid,
+	name = argv[1];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -408,49 +303,14 @@ int cmd_find_sensor(int argc, char **argv)
 int cmd_find_slice(int argc, char **argv)
 {
 
-	int err;
-	static int ask_uuid = 0;
-	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {0, 0, 0, 0},
-	};
-
-	static const char *cmd_run_short_options = ":u";
-
-	int c;
-	int option_index = 0;
-	while (1) {
-		c = getopt_long(argc, argv, cmd_run_short_options,
-		                cmd_run_long_options, &option_index);
-		if (c == -1)
-			break;
-		switch (c) {
-		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
-			break;
-		case '?':
-			return EXIT_FAILURE;
-		default:
-			return EXIT_FAILURE;
-		}
-	}
-	/* remove the parsed part */
-	argc -= optind;
-	argv = &(argv[optind]);
-
-	if (argc < 1)
+	if (argc < 2)
 		return EXIT_FAILURE;
 
+	int err;
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SLICE, name, uuid,
+	name = argv[1];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SLICE, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -473,11 +333,15 @@ int cmd_find_slice(int argc, char **argv)
 	return 0;
 }
 
-int client_listen_callback(nrm_uuid_t uuid,
+int client_listen_callback(nrm_sensor_t *sensor,
                            nrm_time_t time,
                            nrm_scope_t scope,
                            double value)
 {
+	(void)sensor;
+	(void)time;
+	(void)scope;
+	(void)value;
 	nrm_log_debug("event\n");
 	return 0;
 }
@@ -631,15 +495,13 @@ int cmd_list_slices(int argc, char **argv)
 int cmd_remove_scope(int argc, char **argv)
 {
 	int err;
-	static int ask_uuid = 0;
 	static int ask_all = 0;
 	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {"all", no_argument, &ask_uuid, 1},
+	        {"all", no_argument, &ask_all, 1},
 	        {0, 0, 0, 0},
 	};
 
-	static const char *cmd_run_short_options = ":ua";
+	static const char *cmd_run_short_options = ":a";
 
 	int c;
 	int option_index = 0;
@@ -650,9 +512,6 @@ int cmd_remove_scope(int argc, char **argv)
 			break;
 		switch (c) {
 		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
 			break;
 		case 'a':
 			ask_all = 1;
@@ -672,12 +531,8 @@ int cmd_remove_scope(int argc, char **argv)
 
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SCOPE, name, uuid,
+	name = argv[0];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SCOPE, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -706,15 +561,13 @@ int cmd_remove_scope(int argc, char **argv)
 int cmd_remove_sensor(int argc, char **argv)
 {
 	int err;
-	static int ask_uuid = 0;
 	static int ask_all = 0;
 	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {"all", no_argument, &ask_uuid, 1},
+	        {"all", no_argument, &ask_all, 1},
 	        {0, 0, 0, 0},
 	};
 
-	static const char *cmd_run_short_options = ":ua";
+	static const char *cmd_run_short_options = ":a";
 
 	int c;
 	int option_index = 0;
@@ -725,9 +578,6 @@ int cmd_remove_sensor(int argc, char **argv)
 			break;
 		switch (c) {
 		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
 			break;
 		case 'a':
 			ask_all = 1;
@@ -747,12 +597,8 @@ int cmd_remove_sensor(int argc, char **argv)
 
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name, uuid,
+	name = argv[0];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -781,15 +627,13 @@ int cmd_remove_sensor(int argc, char **argv)
 int cmd_remove_slice(int argc, char **argv)
 {
 	int err;
-	static int ask_uuid = 0;
 	static int ask_all = 0;
 	static struct option cmd_run_long_options[] = {
-	        {"uuid", no_argument, &ask_uuid, 1},
-	        {"all", no_argument, &ask_uuid, 1},
+	        {"all", no_argument, &ask_all, 1},
 	        {0, 0, 0, 0},
 	};
 
-	static const char *cmd_run_short_options = ":ua";
+	static const char *cmd_run_short_options = ":a";
 
 	int c;
 	int option_index = 0;
@@ -800,9 +644,6 @@ int cmd_remove_slice(int argc, char **argv)
 			break;
 		switch (c) {
 		case 0:
-			break;
-		case 'u':
-			ask_uuid = 1;
 			break;
 		case 'a':
 			ask_all = 1;
@@ -822,12 +663,8 @@ int cmd_remove_slice(int argc, char **argv)
 
 	nrm_vector_t *results;
 	char *name = NULL;
-	nrm_uuid_t *uuid = NULL;
-	if (ask_uuid)
-		uuid = nrm_uuid_create_fromchar(argv[0]);
-	else
-		name = argv[0];
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SLICE, name, uuid,
+	name = argv[1];
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SLICE, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");
@@ -864,7 +701,7 @@ int cmd_send_event(int argc, char **argv)
 	/* find sensor */
 	int err;
 	nrm_vector_t *results;
-	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name, NULL,
+	err = nrm_client_find(client, NRM_MSG_TARGET_TYPE_SENSOR, name,
 	                      &results);
 	if (err) {
 		nrm_log_error("error during client request\n");

--- a/src/eventbase.c
+++ b/src/eventbase.c
@@ -95,14 +95,14 @@ struct nrm_scope2ring_s *nrm_eventbase_add_scope(nrm_eventbase_t *eb,
 }
 
 struct nrm_sensor2scope_s *nrm_eventbase_add_sensor(nrm_eventbase_t *eb,
-                                                    nrm_uuid_t *sensor_uuid)
+                                                    nrm_string_t sensor_uuid)
 {
 	/* add a sensor2scope to the hash table */
 	struct nrm_sensor2scope_s *s;
 	s = calloc(1, sizeof(struct nrm_sensor2scope_s));
 	if (s == NULL)
 		return NULL;
-	s->uuid = nrm_uuid_to_string(sensor_uuid);
+	s->uuid = sensor_uuid;
 	s->list = NULL;
 	HASH_ADD_STR(eb->hash, uuid, s);
 	return s;
@@ -129,15 +129,14 @@ int nrm_eventbase_remove_sensor(nrm_eventbase_t *eb, nrm_uuid_t *sensor_uuid)
 }
 
 int nrm_eventbase_push_event(nrm_eventbase_t *eb,
-                             nrm_uuid_t *sensor_uuid,
+                             nrm_string_t sensor_uuid,
                              nrm_scope_t *scope,
                              nrm_time_t time,
                              double value)
 {
 	struct nrm_sensor2scope_s *s2s;
 	struct nrm_scope2ring_s *s2r;
-	char *uuid = nrm_uuid_to_char(sensor_uuid);
-	HASH_FIND_STR(eb->hash, uuid, s2s);
+	HASH_FIND_STR(eb->hash, sensor_uuid, s2s);
 	if (s2s == NULL)
 		s2s = nrm_eventbase_add_sensor(eb, sensor_uuid);
 	DL_FOREACH(s2s->list, s2r)

--- a/src/msg.proto
+++ b/src/msg.proto
@@ -32,18 +32,15 @@ message Event {
 }
 
 message Sensor {
-	string name = 1;
-	string uuid = 2;
+	string uuid = 1;
 }
 
 message Slice {
-	string name = 1;
-	string uuid = 2;
+	string uuid = 1;
 }
 
 message Actuator {
-	string name = 1;
-	string uuid = 2;
+	string uuid = 1;
 	string clientid = 3;
 	double value = 4;
 	repeated double choices = 5;

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -19,28 +19,22 @@
 
 #include "internal/nrmi.h"
 
-nrm_sensor_t *nrm_sensor_create(char *name)
+nrm_sensor_t *nrm_sensor_create(const char *name)
 {
 	nrm_sensor_t *ret = calloc(1, sizeof(nrm_sensor_t));
-	ret->name = nrm_string_fromchar(name);
-	ret->uuid = NULL;
+	ret->uuid = nrm_string_fromchar(name);
 	return ret;
 }
 
 json_t *nrm_sensor_to_json(nrm_sensor_t *sensor)
 {
-	json_t *uuid = NULL;
-
-	if (sensor->uuid != NULL)
-		uuid = nrm_uuid_to_json(sensor->uuid);
-	return json_pack("{s:s, s:o*}", "name", sensor->name, "uuid", uuid);
+	return json_pack("{s:s}", "uuid", sensor->uuid);
 }
 
 void nrm_sensor_destroy(nrm_sensor_t **sensor)
 {
 	if (sensor == NULL || *sensor == NULL)
 		return;
-	nrm_string_decref(&(*sensor)->name);
-	nrm_uuid_destroy(&(*sensor)->uuid);
+	nrm_string_decref((*sensor)->uuid);
 	*sensor = NULL;
 }

--- a/src/slices.c
+++ b/src/slices.c
@@ -19,28 +19,22 @@
 
 #include "internal/nrmi.h"
 
-nrm_slice_t *nrm_slice_create(char *name)
+nrm_slice_t *nrm_slice_create(const char *name)
 {
 	nrm_slice_t *ret = calloc(1, sizeof(nrm_slice_t));
-	ret->name = nrm_string_fromchar(name);
-	ret->uuid = NULL;
+	ret->uuid = nrm_string_fromchar(name);
 	return ret;
 }
 
 json_t *nrm_slice_to_json(nrm_slice_t *slice)
 {
-	json_t *uuid = NULL;
-
-	if (slice->uuid != NULL)
-		uuid = nrm_uuid_to_json(slice->uuid);
-	return json_pack("{s:s, s:o*}", "name", slice->name, "uuid", uuid);
+	return json_pack("{s:s}", "uuid", slice->uuid);
 }
 
 void nrm_slice_destroy(nrm_slice_t **slice)
 {
 	if (slice == NULL || *slice == NULL)
 		return;
-	nrm_string_decref(&(*slice)->name);
-	nrm_uuid_destroy(&(*slice)->uuid);
+	nrm_string_decref((*slice)->uuid);
 	*slice = NULL;
 }

--- a/src/utils/scopes.c
+++ b/src/utils/scopes.c
@@ -109,7 +109,7 @@ int nrm_scope_from_json(nrm_scope_t *scope, json_t *json)
 		return -NRM_EINVAL;
 	}
 	if (uuid)
-		scope->uuid = nrm_uuid_create_fromchar(uuid);
+		scope->uuid = nrm_string_fromchar(uuid);
 	nrm_bitmap_from_json(&scope->maps[0], cpu);
 	nrm_bitmap_from_json(&scope->maps[1], numa);
 	nrm_bitmap_from_json(&scope->maps[2], gpu);

--- a/src/utils/strings.c
+++ b/src/utils/strings.c
@@ -57,9 +57,6 @@ nrm_string_t nrm_string_fromchar(const char *string)
 
 nrm_string_t nrm_string_frombuf(const char *string, size_t len)
 {
-	/* from libc example, computes the number of characters needed to print
-	 * the string
-	 */
 	nrm_realstring_t *rs = nrm_string_new(len);
 	if (rs == NULL)
 		return NULL;
@@ -67,15 +64,15 @@ nrm_string_t nrm_string_frombuf(const char *string, size_t len)
 	memcpy(ret, string, len);
 	return ret;
 }
-void nrm_string_incref(nrm_string_t *s)
+void nrm_string_incref(nrm_string_t s)
 {
-	nrm_realstring_t *r = NRM_STRING_C2S(*s);
+	nrm_realstring_t *r = NRM_STRING_C2S(s);
 	r->rc++;
 }
 
-void nrm_string_decref(nrm_string_t *s)
+void nrm_string_decref(nrm_string_t s)
 {
-	nrm_realstring_t *r = NRM_STRING_C2S(*s);
+	nrm_realstring_t *r = NRM_STRING_C2S(s);
 	r->rc--;
 	if (r->rc == 0)
 		free(r);

--- a/src/utils/uuids.c
+++ b/src/utils/uuids.c
@@ -38,7 +38,7 @@ void nrm_uuid_destroy(nrm_uuid_t **uuid)
 	if (uuid == NULL || *uuid == NULL)
 		return;
 
-	nrm_string_decref(*uuid);
+	nrm_string_decref(**uuid);
 	free(*uuid);
 	*uuid = NULL;
 }
@@ -71,7 +71,7 @@ nrm_string_t nrm_uuid_to_string(nrm_uuid_t *uuid)
 {
 	if (uuid == NULL)
 		return NULL;
-	nrm_string_incref(uuid);
+	nrm_string_incref(*uuid);
 	return *uuid;
 }
 


### PR DESCRIPTION
We will only use a single uuid field per object, and allow this field to be any arbitrary string.

We will only come up with a naming scheme for sensors, actuators, slices, and scopes that are provided by the infra.