### PR TITLE
[fix] add name to scope at creation time

### DIFF
--- a/include/nrm/utils/scopes.h
+++ b/include/nrm/utils/scopes.h
@@ -25,7 +25,7 @@ typedef struct nrm_scope nrm_scope_t;
 /**
  * Creates and returns a new NRM scope
  */
-nrm_scope_t *nrm_scope_create(void);
+nrm_scope_t *nrm_scope_create(const char *name);
 
 #define NRM_SCOPE_TYPE_CPU 0
 #define NRM_SCOPE_TYPE_NUMA 1

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 	}
 
 	nrm_log_info("creating dummy scope\n");
-	scope = nrm_scope_create();
+	scope = nrm_scope_create("nrm.scope.package.0");
 	nrm_scope_threadprivate(scope);
 	err = nrm_client_add_scope(client, scope);
 	if (err) {

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -138,15 +138,15 @@ int cmd_add_scope(int argc, char **argv)
 {
 
 	/* no matter the arguments, only one extra parameter */
-	if (argc != 2)
+	if (argc != 3)
 		return EXIT_FAILURE;
 
 	int err;
 	nrm_scope_t *scope;
 	json_t *param;
 	json_error_t json_error;
-	param = json_loads(argv[1], 0, &json_error);
-	scope = nrm_scope_create();
+	param = json_loads(argv[2], 0, &json_error);
+	scope = nrm_scope_create(argv[1]);
 	err = nrm_scope_from_json(scope, param);
 	if (err)
 		return EXIT_FAILURE;
@@ -693,10 +693,11 @@ int cmd_remove_slice(int argc, char **argv)
 int cmd_send_event(int argc, char **argv)
 {
 	/* no options at this time */
-	if (argc < 2)
+	if (argc < 3)
 		return EXIT_FAILURE;
 
 	char *name = argv[1];
+	char *scope_name = argv[2];
 
 	/* find sensor */
 	int err;
@@ -718,7 +719,7 @@ int cmd_send_event(int argc, char **argv)
 	s = (nrm_sensor_t *)p;
 
 	nrm_log_info("sending event\n");
-	nrm_scope_t *scope = nrm_scope_create();
+	nrm_scope_t *scope = nrm_scope_create(scope_name);
 	nrm_scope_threadprivate(scope);
 	nrm_time_t time;
 	nrm_time_gettime(&time);

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -362,8 +362,7 @@ int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
 	/* create an event */
 	nrm_time_t now;
 	nrm_time_gettime(&now);
-	nrm_scope_t *scope = nrm_scope_create();
-	scope->uuid = nrm_string_fromchar("nrm.scope.all");
+	nrm_scope_t *scope = nrm_scope_create("nrm.scope.all");
 	nrm_scope_threadprivate(scope);
 	nrm_sensor_t *sensor = nrm_sensor_create("daemon.tick");
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -407,7 +407,7 @@ nrm_scope_t *nrm_scope_create_frommsg(nrm_msg_scope_t *msg)
 {
 	if (msg == NULL)
 		return NULL;
-	nrm_scope_t *ret = nrm_scope_create();
+	nrm_scope_t *ret = nrm_scope_create(msg->uuid);
 	nrm_bitmap_from_array(&ret->maps[NRM_SCOPE_TYPE_CPU], msg->n_cpus,
 	                      msg->cpus);
 	nrm_bitmap_from_array(&ret->maps[NRM_SCOPE_TYPE_NUMA], msg->n_numas,

--- a/src/utils/scopes.c
+++ b/src/utils/scopes.c
@@ -19,9 +19,11 @@
 
 #include "internal/nrmi.h"
 
-nrm_scope_t *nrm_scope_create()
+nrm_scope_t *nrm_scope_create(const char *name)
 {
-	return calloc(1, sizeof(nrm_scope_t));
+	nrm_scope_t *ret = calloc(1, sizeof(nrm_scope_t));
+	ret->uuid = nrm_string_fromchar(name);
+	return ret;
 }
 
 int nrm_scope_add(nrm_scope_t *s, unsigned int type, unsigned int num)
@@ -47,7 +49,7 @@ int nrm_scope_destroy(nrm_scope_t *s)
 
 nrm_scope_t *nrm_scope_dup(nrm_scope_t *s)
 {
-	nrm_scope_t *ret = nrm_scope_create();
+	nrm_scope_t *ret = nrm_scope_create(s->uuid);
 	for (size_t i = 0; i < NRM_SCOPE_TYPE_MAX; i++)
 		nrm_bitmap_copy(&ret->maps[i], &s->maps[i]);
 	return ret;

--- a/tests/utils/scope.c
+++ b/tests/utils/scope.c
@@ -20,7 +20,7 @@ START_TEST(test_from_json)
 {
 
 	json_t *valid_cpu_scope = json_loads("{\"cpu\": [0]}", 0, NULL);
-	nrm_scope_t *scope = nrm_scope_create();
+	nrm_scope_t *scope = nrm_scope_create("test");
 	nrm_scope_from_json(scope, valid_cpu_scope);
 	assert(nrm_bitmap_isset(&scope->maps[NRM_SCOPE_TYPE_CPU], 0));
 }


### PR DESCRIPTION
Fix an issue with scopes needing a uuid but not being able to set that name from the public API.