### PR TITLE
[feature/fix] activate valgrind checks in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -59,6 +59,28 @@ jobs:
           path: |
             out/config.log
             out/*.log
+  valgrind:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 libczmq-dev libczmq4 libprotobuf-c-dev protobuf-c-compiler libjansson-dev libjansson4 check libhwloc-dev valgrind
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: configure
+        run: |
+          ./autogen.sh
+          mkdir build
+          ./configure --prefix=`pwd`/build --enable-valgrind
+      - run: make
+      - run: make check-valgrind
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: valgrind
+          path: |
+            config.log
+            *.log
   nix:
     runs-on: ubuntu-latest
     steps:

--- a/src/utils/hashes.c
+++ b/src/utils/hashes.c
@@ -70,9 +70,9 @@ void nrm_hash_destroy(nrm_hash_t **hash_table)
 	HASH_ITER(hh, (*hash_table), iterator, tmp)
 	{
 		HASH_DEL((*hash_table), iterator);
-		free(tmp);
+		free(iterator);
 	}
-	free(iterator);
+	*hash_table = NULL;
 }
 
 int nrm_hash_find(nrm_hash_t *hash_table, nrm_string_t uuid, void **ptr)

--- a/src/utils/scopes.c
+++ b/src/utils/scopes.c
@@ -42,6 +42,7 @@ size_t nrm_scope_length(const nrm_scope_t *s, unsigned int type)
 
 int nrm_scope_destroy(nrm_scope_t *s)
 {
+	nrm_string_decref(s->uuid);
 	free(s);
 	return 0;
 }

--- a/tests/net.c
+++ b/tests/net.c
@@ -80,6 +80,8 @@ START_TEST(test_send_onemsg_rpc)
 	ck_assert_ptr_nonnull(recvbuf);
 	ck_assert_ptr_nonnull(identity);
 	ck_assert_str_eq(recvbuf, sndbuf);
+	free(recvbuf);
+	free(identity);
 }
 END_TEST
 
@@ -93,6 +95,7 @@ START_TEST(test_send_onemsg_pubsub)
 	ck_assert(!zsock_recv(client, "s", &recvbuf));
 	ck_assert_ptr_nonnull(recvbuf);
 	ck_assert_str_eq(recvbuf, sndbuf);
+	free(recvbuf);
 }
 END_TEST
 

--- a/tests/utils/scope.c
+++ b/tests/utils/scope.c
@@ -23,6 +23,8 @@ START_TEST(test_from_json)
 	nrm_scope_t *scope = nrm_scope_create("test");
 	nrm_scope_from_json(scope, valid_cpu_scope);
 	assert(nrm_bitmap_isset(&scope->maps[NRM_SCOPE_TYPE_CPU], 0));
+	nrm_scope_destroy(scope);
+	json_decref(valid_cpu_scope);
 }
 END_TEST
 

--- a/tests/utils/vector.c
+++ b/tests/utils/vector.c
@@ -12,6 +12,14 @@
 #include <check.h>
 #include <stdlib.h>
 
+int test_nrm_strcmp(const void *a, const void *b)
+{
+	nrm_string_t *one, *two;
+	one = (nrm_string_t *)a;
+	two = (nrm_string_t *)b;
+	return nrm_string_cmp(*one, *two);
+}
+
 START_TEST(test_basics)
 {
 	nrm_vector_t *vector = NULL;
@@ -30,7 +38,7 @@ START_TEST(test_basics)
 	ck_assert_int_eq(err, 0);
 
 	size_t pos;
-	err = nrm_vector_find(vector, &fortytwo, nrm_string_cmp, &pos);
+	err = nrm_vector_find(vector, &fortytwo, test_nrm_strcmp, &pos);
 	ck_assert_int_eq(err, 0);
 	ck_assert_int_eq(pos, 1);
 


### PR DESCRIPTION
Valgrind was already setup in configure & make but was missing from the CI. Add a new step to ensure that our unit tests are leak free.

Fix a few leaks detected along the way.