### PR TITLE
[refactor] introduce server object

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   generic:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 libczmq-dev libczmq4 libprotobuf-c-dev protobuf-c-compiler libjansson-dev libjansson4 check libhwloc-dev bats
@@ -33,6 +34,7 @@ jobs:
             *.log
   out-of-tree:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 libczmq-dev libczmq4 libprotobuf-c-dev protobuf-c-compiler libjansson-dev libjansson4 check libhwloc-dev bats
@@ -61,6 +63,7 @@ jobs:
             out/*.log
   valgrind:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 libczmq-dev libczmq4 libprotobuf-c-dev protobuf-c-compiler libjansson-dev libjansson4 check libhwloc-dev valgrind bats
@@ -93,6 +96,7 @@ jobs:
       - run: nix-build -A libnrm
   distcheck:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libzmq3-dev libzmq5 libczmq-dev libczmq4 libprotobuf-c-dev protobuf-c-compiler libjansson-dev libjansson4 check libhwloc-dev bats

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,8 +101,9 @@ libnrm_la_SOURCES = \
 		 src/roles/client.c \
 		 src/roles/controller.c \
 		 src/roles/role.c \
-		 src/slices.c \
 		 src/sensor.c \
+		 src/server.c \
+		 src/slices.c \
 		 src/state.c \
 		 src/utils/bitmaps.c \
 		 src/utils/error.c \

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -426,7 +426,20 @@ void nrm_client_destroy(nrm_client_t **client);
 
 typedef struct nrm_server_s nrm_server_t;
 
-typedef int(nrm_server_callback_fn)(void *arg);
+/** User-level callbacks on server events */
+struct nrm_server_user_callbacks_s {
+	/* receiving a sensor event */
+	int(*event)(nrm_server_t *, nrm_string_t, nrm_scope_t *,
+		    nrm_time_t, double value);
+	/* receiving a request to actuate */
+	int(*actuate)(nrm_server_t *, nrm_actuator_t *, double value);
+	/* receiving a POSIX signal */
+	int(*signal)(nrm_server_t *, int);
+	/* timer trigger */
+	int(*timer)(nrm_server_t *);
+};
+
+typedef struct nrm_server_user_callbacks_s nrm_server_user_callbacks_t;
 
 /**
  * Creates a new NRM server.
@@ -447,6 +460,19 @@ int nrm_server_create(nrm_server_t **server, nrm_state_t *state,
                       int pub_port,
                       int rpc_port);
 
+int nrm_server_setcallbacks(nrm_server_t *server, nrm_server_user_callbacks_t
+			    callbacks);
+
+int nrm_server_settimer(nrm_server_t *server, int millisecs);
+
+int nrm_server_start(nrm_server_t *server);
+
+int nrm_server_publish(nrm_server_t *server, nrm_string_t topic,
+		       nrm_time_t now, nrm_sensor_t *sensor,
+		       nrm_scope_t *scope,
+		       double value);
+
+int nrm_server_actuate(nrm_server_t *server, nrm_string_t uuid, double value);
 
 /**
  * Destroys an NRM server. Closes connections.

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -200,14 +200,29 @@ void nrm_sensor_destroy(nrm_sensor_t **);
 
 struct nrm_state_s {
 	nrm_hash_t *actuators;
-	nrm_hash_t *slices;
-	nrm_hash_t *sensors;
 	nrm_hash_t *scopes;
+	nrm_hash_t *sensors;
+	nrm_hash_t *slices;
 };
 
 typedef struct nrm_state_s nrm_state_t;
 
 nrm_state_t *nrm_state_create(void);
+
+int nrm_state_list_actuators(nrm_state_t *, nrm_vector_t *);
+int nrm_state_list_scopes(nrm_state_t *, nrm_vector_t *);
+int nrm_state_list_sensors(nrm_state_t *, nrm_vector_t *);
+int nrm_state_list_slices(nrm_state_t *, nrm_vector_t *);
+
+int nrm_state_add_actuator(nrm_state_t *, nrm_actuator_t *);
+int nrm_state_add_scope(nrm_state_t *, nrm_scope_t *);
+int nrm_state_add_sensor(nrm_state_t *, nrm_sensor_t *);
+int nrm_state_add_slice(nrm_state_t *, nrm_slice_t *);
+
+int nrm_state_remove_actuator(nrm_state_t *, const char *uuid);
+int nrm_state_remove_scope(nrm_state_t *, const char *uuid);
+int nrm_state_remove_sensor(nrm_state_t *, const char *uuid);
+int nrm_state_remove_slice(nrm_state_t *, const char *uuid);
 
 void nrm_state_destroy(nrm_state_t **);
 
@@ -416,14 +431,18 @@ typedef int(nrm_server_callback_fn)(void *arg);
 /**
  * Creates a new NRM server.
  *
+ * Uses a state to keep track of server objects that clients can add/remove
+ * from the system.
+ *
  * @param server: pointer to a variable that will contain the server handle
+ * @param server: pointer to a valid state handle
  * @param uri: address for listening to clients
  * @param pub_port: port for publishing server events
  * @param rpc_port: port for listening to requests
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_server_create(nrm_server_t **server,
+int nrm_server_create(nrm_server_t **server, nrm_state_t *state,
                       const char *uri,
                       int pub_port,
                       int rpc_port);
@@ -432,7 +451,7 @@ int nrm_server_create(nrm_server_t **server,
 /**
  * Destroys an NRM server. Closes connections.
  */
-void nrm_server_destroy(nrm_client_t **client);
+void nrm_server_destroy(nrm_server_t **server);
 
 #ifdef __cplusplus
 }

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -429,14 +429,17 @@ typedef struct nrm_server_s nrm_server_t;
 /** User-level callbacks on server events */
 struct nrm_server_user_callbacks_s {
 	/* receiving a sensor event */
-	int(*event)(nrm_server_t *, nrm_string_t, nrm_scope_t *,
-		    nrm_time_t, double value);
+	int (*event)(nrm_server_t *,
+	             nrm_string_t,
+	             nrm_scope_t *,
+	             nrm_time_t,
+	             double value);
 	/* receiving a request to actuate */
-	int(*actuate)(nrm_server_t *, nrm_actuator_t *, double value);
+	int (*actuate)(nrm_server_t *, nrm_actuator_t *, double value);
 	/* receiving a POSIX signal */
-	int(*signal)(nrm_server_t *, int);
+	int (*signal)(nrm_server_t *, int);
 	/* timer trigger */
-	int(*timer)(nrm_server_t *);
+	int (*timer)(nrm_server_t *);
 };
 
 typedef struct nrm_server_user_callbacks_s nrm_server_user_callbacks_t;
@@ -455,22 +458,25 @@ typedef struct nrm_server_user_callbacks_s nrm_server_user_callbacks_t;
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_server_create(nrm_server_t **server, nrm_state_t *state,
+int nrm_server_create(nrm_server_t **server,
+                      nrm_state_t *state,
                       const char *uri,
                       int pub_port,
                       int rpc_port);
 
-int nrm_server_setcallbacks(nrm_server_t *server, nrm_server_user_callbacks_t
-			    callbacks);
+int nrm_server_setcallbacks(nrm_server_t *server,
+                            nrm_server_user_callbacks_t callbacks);
 
 int nrm_server_settimer(nrm_server_t *server, int millisecs);
 
 int nrm_server_start(nrm_server_t *server);
 
-int nrm_server_publish(nrm_server_t *server, nrm_string_t topic,
-		       nrm_time_t now, nrm_sensor_t *sensor,
-		       nrm_scope_t *scope,
-		       double value);
+int nrm_server_publish(nrm_server_t *server,
+                       nrm_string_t topic,
+                       nrm_time_t now,
+                       nrm_sensor_t *sensor,
+                       nrm_scope_t *scope,
+                       double value);
 
 int nrm_server_actuate(nrm_server_t *server, nrm_string_t uuid, double value);
 

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -403,6 +403,37 @@ int nrm_client_start_actuate_listener(const nrm_client_t *client);
  */
 void nrm_client_destroy(nrm_client_t **client);
 
+/*******************************************************************************
+ * NRM Server object
+ * Used by any program that wants to act as a control loop: it can receive
+ * requests from clients and send actions back.
+ ******************************************************************************/
+
+typedef struct nrm_server_s nrm_server_t;
+
+typedef int(nrm_server_callback_fn)(void *arg);
+
+/**
+ * Creates a new NRM server.
+ *
+ * @param server: pointer to a variable that will contain the server handle
+ * @param uri: address for listening to clients
+ * @param pub_port: port for publishing server events
+ * @param rpc_port: port for listening to requests
+ * @return 0 if successful, an error code otherwise
+ *
+ */
+int nrm_server_create(nrm_server_t **server,
+                      const char *uri,
+                      int pub_port,
+                      int rpc_port);
+
+
+/**
+ * Destroys an NRM server. Closes connections.
+ */
+void nrm_server_destroy(nrm_client_t **client);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -22,6 +22,7 @@
 
 struct nrm_daemon_s {
 	nrm_state_t *state;
+	nrm_server_t *server;
 	nrm_eventbase_t *events;
 	nrm_control_t *control;
 	nrm_sensor_t *mysensor;
@@ -32,355 +33,22 @@ struct nrm_daemon_s {
 int signo;
 struct nrm_daemon_s my_daemon;
 
-nrm_msg_t *nrmd_daemon_remove_actuator(nrm_msg_remove_t *msg)
+int nrmd_event_callback(nrm_server_t *server, nrm_string_t uuid,
+			nrm_scope_t *scope, nrm_time_t time, double value)
 {
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_actuator_t *actuator = NULL;
-	nrm_hash_remove(&my_daemon.state->actuators, uuid, (void *)&actuator);
-	nrm_actuator_destroy(&actuator);
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_remove_scope(nrm_msg_remove_t *msg)
-{
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_scope_t *scope = NULL;
-	nrm_hash_remove(&my_daemon.state->scopes, uuid, (void *)&scope);
-	nrm_scope_destroy(scope);
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_remove_sensor(nrm_msg_remove_t *msg)
-{
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_sensor_t *sensor = NULL;
-	nrm_hash_remove(&my_daemon.state->sensors, uuid, (void *)&sensor);
-	nrm_sensor_destroy(&sensor);
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_remove_slice(nrm_msg_remove_t *msg)
-{
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_slice_t *slice = NULL;
-	nrm_hash_remove(&my_daemon.state->slices, uuid, (void *)&slice);
-	nrm_slice_destroy(&slice);
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_build_list_actuators()
-{
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_LIST);
-
-	nrm_vector_t *actuators_vector = NULL;
-	nrm_vector_create(&actuators_vector, sizeof(nrm_actuator_t));
-
-	nrm_hash_foreach(my_daemon.state->actuators, iter)
-	{
-		nrm_actuator_t *actuator = nrm_hash_iterator_get(iter);
-		nrm_vector_push_back(actuators_vector, actuator);
-	}
-
-	nrm_msg_set_list_actuators(ret, actuators_vector);
-	nrm_vector_destroy(&actuators_vector);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_build_list_scopes()
-{
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_LIST);
-
-	nrm_vector_t *scopes_vector = NULL;
-	nrm_vector_create(&scopes_vector, sizeof(nrm_scope_t));
-
-	nrm_hash_foreach(my_daemon.state->scopes, iter)
-	{
-		nrm_scope_t *scope = nrm_hash_iterator_get(iter);
-		nrm_vector_push_back(scopes_vector, scope);
-	}
-
-	nrm_msg_set_list_scopes(ret, scopes_vector);
-	nrm_vector_destroy(&scopes_vector);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_build_list_sensors()
-{
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_LIST);
-
-	nrm_vector_t *sensors_vector = NULL;
-	nrm_vector_create(&sensors_vector, sizeof(nrm_sensor_t));
-
-	nrm_hash_foreach(my_daemon.state->sensors, iter)
-	{
-		nrm_sensor_t *sensor = nrm_hash_iterator_get(iter);
-		nrm_vector_push_back(sensors_vector, sensor);
-	}
-
-	nrm_msg_set_list_sensors(ret, sensors_vector);
-	nrm_vector_destroy(&sensors_vector);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_build_list_slices()
-{
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_LIST);
-
-	nrm_vector_t *slices_vector = NULL;
-	nrm_vector_create(&slices_vector, sizeof(nrm_slice_t));
-
-	nrm_hash_foreach(my_daemon.state->slices, iter)
-	{
-		nrm_slice_t *slice = nrm_hash_iterator_get(iter);
-		nrm_vector_push_back(slices_vector, slice);
-	}
-
-	nrm_msg_set_list_slices(ret, slices_vector);
-	nrm_vector_destroy(&slices_vector);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_add_actuator(nrm_uuid_t *clientid,
-                                    nrm_msg_actuator_t *actuator)
-{
-	nrm_actuator_t *newactuator = nrm_actuator_create_frommsg(actuator);
-	newactuator->clientid =
-	        nrm_uuid_create_fromchar(nrm_uuid_to_char(clientid));
-
-	nrm_hash_add(&my_daemon.state->actuators, newactuator->uuid,
-	             newactuator);
-
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ADD);
-	nrm_msg_set_add_actuator(ret, newactuator);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_add_scope(nrm_msg_scope_t *scope)
-{
-	nrm_scope_t *newscope = nrm_scope_create_frommsg(scope);
-
-	nrm_hash_add(&my_daemon.state->scopes, newscope->uuid, newscope);
-
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ADD);
-	nrm_msg_set_add_scope(ret, newscope);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_add_sensor(const char *name)
-{
-	nrm_sensor_t *newsensor = nrm_sensor_create(name);
-
-	nrm_hash_add(&my_daemon.state->sensors, newsensor->uuid, newsensor);
-
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ADD);
-	nrm_msg_set_add_sensor(ret, newsensor);
-	return ret;
-}
-
-nrm_msg_t *nrmd_daemon_add_slice(const char *name)
-{
-	nrm_slice_t *newslice = nrm_slice_create(name);
-
-	nrm_hash_add(&my_daemon.state->slices, newslice->uuid, newslice);
-
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ADD);
-	nrm_msg_set_add_slice(ret, newslice);
-	return ret;
-}
-
-nrm_msg_t *nrmd_handle_add_request(nrm_uuid_t *clientid, nrm_msg_add_t *msg)
-{
-	nrm_msg_t *ret = NULL;
-	switch (msg->type) {
-	case NRM_MSG_TARGET_TYPE_ACTUATOR:
-		nrm_log_info("adding an actuator\n");
-		ret = nrmd_daemon_add_actuator(clientid, msg->actuator);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SLICE:
-		nrm_log_info("adding a slice\n");
-		ret = nrmd_daemon_add_slice(msg->slice->uuid);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SENSOR:
-		nrm_log_info("adding a sensor\n");
-		ret = nrmd_daemon_add_sensor(msg->sensor->uuid);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SCOPE:
-		nrm_log_info("adding a scope\n");
-		ret = nrmd_daemon_add_scope(msg->scope);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	default:
-		nrm_log_error("wrong add request type %u\n", msg->type);
-		break;
-	}
-	return ret;
-}
-
-nrm_msg_t *nrmd_handle_list_request(nrm_msg_list_t *msg)
-{
-	nrm_msg_t *ret = NULL;
-	switch (msg->type) {
-	case NRM_MSG_TARGET_TYPE_ACTUATOR:
-		nrm_log_info("building list of actuators\n");
-		ret = nrmd_daemon_build_list_actuators();
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SLICE:
-		nrm_log_info("building list of slices\n");
-		ret = nrmd_daemon_build_list_slices();
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SENSOR:
-		nrm_log_info("building list of sensors\n");
-		ret = nrmd_daemon_build_list_sensors();
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SCOPE:
-		nrm_log_info("building list of scopes\n");
-		ret = nrmd_daemon_build_list_scopes();
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	default:
-		nrm_log_error("wrong list request type %u\n", msg->type);
-		break;
-	}
-	return ret;
-}
-
-nrm_msg_t *nrmd_handle_remove_request(nrm_msg_remove_t *msg)
-{
-	nrm_msg_t *ret = NULL;
-	switch (msg->type) {
-	case NRM_MSG_TARGET_TYPE_ACTUATOR:
-		nrm_log_info("removing an actuator\n");
-		ret = nrmd_daemon_remove_actuator(msg);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SLICE:
-		nrm_log_info("removing a slice\n");
-		ret = nrmd_daemon_remove_slice(msg);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SENSOR:
-		nrm_log_info("removing a sensor\n");
-		ret = nrmd_daemon_remove_sensor(msg);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	case NRM_MSG_TARGET_TYPE_SCOPE:
-		nrm_log_info("removing a scope\n");
-		ret = nrmd_daemon_remove_scope(msg);
-		nrm_log_printmsg(NRM_LOG_DEBUG, ret);
-		break;
-	default:
-		nrm_log_error("wrong list request type %u\n", msg->type);
-		break;
-	}
-	return ret;
-}
-
-int nrmd_handle_event_request(nrm_msg_event_t *msg)
-{
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_scope_t *scope = nrm_scope_create_frommsg(msg->scope);
-	nrm_time_t time = nrm_time_fromns(msg->time);
-	nrm_eventbase_push_event(my_daemon.events, uuid, scope, time,
-	                         msg->value);
+	(void)server;
+	/* TODO also publish the raw events */
+	nrm_eventbase_push_event(my_daemon.events, uuid, scope, time, value);
 	return 0;
 }
 
-nrm_msg_t *nrmd_handle_actuate_request(nrm_role_t *role, nrm_msg_actuate_t *msg)
+int nrmd_actuate_callback(nrm_server_t *server, nrm_actuator_t *a, double value)
 {
-	nrm_string_t uuid = nrm_string_fromchar(msg->uuid);
-	nrm_actuator_t *a = NULL;
-	nrm_hash_find(my_daemon.state->actuators, uuid, (void *)&a);
-	if (a != NULL) {
-		/* found the actuator */
-		nrm_log_debug("actuating %s: %f\n", a->uuid, msg->value);
-		nrm_msg_t *action = nrm_msg_create();
-		nrm_msg_fill(action, NRM_MSG_TYPE_ACTUATE);
-		nrm_msg_set_actuate(action, a->uuid, msg->value);
-		nrm_role_send(role, action, a->clientid);
-	}
-
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-nrm_msg_t *nrmd_handle_exit_request(nrm_role_t *role)
-{
-	(void)role;
-	/* just ack the message and exit the daemon */
-	nrm_msg_t *ret = nrm_msg_create();
-	nrm_msg_fill(ret, NRM_MSG_TYPE_ACK);
-	return ret;
-}
-
-int nrmd_shim_controller_read_callback(zloop_t *loop,
-                                       zsock_t *socket,
-                                       void *arg)
-{
-	(void)loop;
-	(void)socket;
-	int err = 0;
-	nrm_log_info("entering callback\n");
-	nrm_role_t *self = (nrm_role_t *)arg;
-	nrm_msg_t *msg, *ret;
-	nrm_uuid_t *uuid;
-	nrm_log_debug("receiving\n");
-	msg = nrm_role_recv(self, &uuid);
-	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
-	switch (msg->type) {
-	case NRM_MSG_TYPE_ACTUATE:
-		ret = nrmd_handle_actuate_request(self, msg->actuate);
-		nrm_role_send(self, ret, uuid);
-		break;
-	case NRM_MSG_TYPE_LIST:
-		ret = nrmd_handle_list_request(msg->list);
-		nrm_role_send(self, ret, uuid);
-		break;
-	case NRM_MSG_TYPE_ADD:
-		ret = nrmd_handle_add_request(uuid, msg->add);
-		nrm_role_send(self, ret, uuid);
-		break;
-	case NRM_MSG_TYPE_EVENT:
-		nrmd_handle_event_request(msg->event);
-		break;
-	case NRM_MSG_TYPE_REMOVE:
-		ret = nrmd_handle_remove_request(msg->remove);
-		nrm_role_send(self, ret, uuid);
-		break;
-	case NRM_MSG_TYPE_EXIT:
-		ret = nrmd_handle_exit_request(self);
-		nrm_role_send(self, ret, uuid);
-		/* that will trigger exit */
-		err = -1;
-		break;
-	default:
-		nrm_log_error("message type not handled\n");
-		break;
-	}
-	nrm_msg_destroy_received(&msg);
-	return err;
+	(void)server;
+	(void)a;
+	(void)value;
+	/* we only allow actuation to happen here */
+	return 0;
 }
 
 double nrmd_actuator_value(nrm_string_t uuid)
@@ -394,40 +62,16 @@ double nrmd_actuator_value(nrm_string_t uuid)
 	return 0.0;
 }
 
-int nrmd_actuate(nrm_role_t *role, nrm_string_t uuid, double value)
+int nrmd_timer_callback(nrm_server_t *server)
 {
-	nrm_actuator_t *a = NULL;
-	nrm_hash_find(my_daemon.state->actuators, uuid, (void *)&a);
-	if (a != NULL) {
-		/* found the actuator */
-		nrm_log_debug("actuating %s: %f\n", a->uuid, value);
-		nrm_msg_t *action = nrm_msg_create();
-		nrm_msg_fill(action, NRM_MSG_TYPE_ACTUATE);
-		nrm_msg_set_actuate(action, a->uuid, value);
-		nrm_role_send(role, action, a->clientid);
-	}
-	return 0;
-}
-
-int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
-{
-	(void)loop;
-	(void)timerid;
 	nrm_log_info("global timer wakeup\n");
-	nrm_role_t *self = (nrm_role_t *)arg;
 
 	/* create a ticking event */
 	nrm_time_t now;
 	nrm_time_gettime(&now);
 
-	nrm_log_debug("crafting message\n");
-	nrm_msg_t *msg = nrm_msg_create();
-	nrm_msg_fill(msg, NRM_MSG_TYPE_EVENT);
-	nrm_msg_set_event(msg, now, my_daemon.mysensor->uuid, my_daemon.myscope,
-	                  1.0);
-	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
-	nrm_log_debug("sending event\n");
-	nrm_role_pub(self, my_daemon.mytopic, msg);
+	nrm_server_publish(server, my_daemon.mytopic, now, my_daemon.mysensor,
+			   my_daemon.myscope, 1.0);
 
 	/* tick the event base */
 	nrm_log_debug("eventbase tick\n");
@@ -462,23 +106,9 @@ int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
 	nrm_vector_foreach(outputs, iterator)
 	{
 		nrm_control_output_t *out = nrm_vector_iterator_get(iterator);
-		nrmd_actuate(self, out->actuator_uuid, out->value);
+		nrm_server_actuate(server, out->actuator_uuid, out->value);
 	}
 	return 0;
-}
-
-/* most logic from https://gist.github.com/mhaberler/8426050 */
-static int
-nrmd_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
-{
-	(void)loop;
-	(void)arg;
-	struct signalfd_siginfo fdsi;
-	ssize_t s = read(poller->fd, &fdsi, sizeof(struct signalfd_siginfo));
-	assert(s == sizeof(struct signalfd_siginfo));
-	signo = fdsi.ssi_signo;
-	nrm_log_debug("Caught SIGINT\n");
-	return -1;
 }
 
 static int ask_help = 0;
@@ -505,7 +135,7 @@ void print_help()
 
 void print_version()
 {
-	fprintf(stdout, "nrmd-shim: version %s\n", nrm_version_string);
+	fprintf(stdout, "nrmd: version %s\n", nrm_version_string);
 }
 
 int main(int argc, char *argv[])
@@ -587,50 +217,34 @@ int main(int argc, char *argv[])
 
 start:
 	nrm_log_info("daemon initialized\n");
-	/* networking */
-	nrm_role_t *controller = nrm_role_controller_create_fromparams(
+
+	/* start the server */
+	err = nrm_server_create(&my_daemon.server, my_daemon.state,
 	        NRM_DEFAULT_UPSTREAM_URI, NRM_DEFAULT_UPSTREAM_PUB_PORT,
 	        NRM_DEFAULT_UPSTREAM_RPC_PORT);
-	assert(controller != NULL);
+	assert(err == 0);
 
-	zloop_t *loop = zloop_new();
-	assert(loop != NULL);
-
-	/* prepare set of signal handlers for zloop */
-	sigset_t sigmask;
-	sigemptyset(&sigmask);
-	sigaddset(&sigmask, SIGINT);
-	// sigaddset(&sigmask, SIGKILL); // SIGKILL is ignored by signalfd
-
-	sfd = signalfd(-1, &sigmask, 0);
-	assert(sfd != -1);
-
-	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN, 0};
-
-	nrm_role_controller_register_recvcallback(
-	        controller, loop, nrmd_shim_controller_read_callback,
-	        controller);
+	/* setting up the callbacks */
+	nrm_server_user_callbacks_t callbacks = {
+		.event = nrmd_event_callback,
+		.actuate = nrmd_actuate_callback,
+		.signal = NULL,
+		.timer = nrmd_timer_callback,
+	};
+	nrm_server_setcallbacks(my_daemon.server, callbacks);
 
 	/* add a periodic wake up to generate metrics */
-	zloop_timer(loop, 1000, 0, nrmd_timer_callback, controller);
-	/* register signal handler callback */
-	zloop_poller(loop, &signal_poller, nrmd_signal_callback, NULL);
+	nrm_server_settimer(my_daemon.server, 1000);
 
-	/* start loop, returns when context terminated,
-	process interrupted, or event handler returns -1 */
-	retval = zloop_start(loop);
-
-	/* teardown zloop */
-	zloop_destroy(&loop);
-	assert(loop == NULL);
-	nrm_log_debug("Loop destroyed\n");
+	/* start the whole thing */
+	nrm_server_start(my_daemon.server);
 
 	/* teardown NRM */
 	nrm_string_decref(my_daemon.mytopic);
 	nrm_sensor_destroy(&my_daemon.mysensor);
 	nrm_eventbase_destroy(&my_daemon.events);
 	nrm_state_destroy(&my_daemon.state);
-	nrm_role_destroy(&controller);
+	nrm_server_destroy(&my_daemon.server);
 	nrm_log_debug("NRM components destroyed\n");
 
 	exit(EXIT_SUCCESS);

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -33,8 +33,11 @@ struct nrm_daemon_s {
 int signo;
 struct nrm_daemon_s my_daemon;
 
-int nrmd_event_callback(nrm_server_t *server, nrm_string_t uuid,
-			nrm_scope_t *scope, nrm_time_t time, double value)
+int nrmd_event_callback(nrm_server_t *server,
+                        nrm_string_t uuid,
+                        nrm_scope_t *scope,
+                        nrm_time_t time,
+                        double value)
 {
 	(void)server;
 	/* TODO also publish the raw events */
@@ -71,7 +74,7 @@ int nrmd_timer_callback(nrm_server_t *server)
 	nrm_time_gettime(&now);
 
 	nrm_server_publish(server, my_daemon.mytopic, now, my_daemon.mysensor,
-			   my_daemon.myscope, 1.0);
+	                   my_daemon.myscope, 1.0);
 
 	/* tick the event base */
 	nrm_log_debug("eventbase tick\n");
@@ -220,16 +223,17 @@ start:
 
 	/* start the server */
 	err = nrm_server_create(&my_daemon.server, my_daemon.state,
-	        NRM_DEFAULT_UPSTREAM_URI, NRM_DEFAULT_UPSTREAM_PUB_PORT,
-	        NRM_DEFAULT_UPSTREAM_RPC_PORT);
+	                        NRM_DEFAULT_UPSTREAM_URI,
+	                        NRM_DEFAULT_UPSTREAM_PUB_PORT,
+	                        NRM_DEFAULT_UPSTREAM_RPC_PORT);
 	assert(err == 0);
 
 	/* setting up the callbacks */
 	nrm_server_user_callbacks_t callbacks = {
-		.event = nrmd_event_callback,
-		.actuate = nrmd_actuate_callback,
-		.signal = NULL,
-		.timer = nrmd_timer_callback,
+	        .event = nrmd_event_callback,
+	        .actuate = nrmd_actuate_callback,
+	        .signal = NULL,
+	        .timer = nrmd_timer_callback,
 	};
 	nrm_server_setcallbacks(my_daemon.server, callbacks);
 

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -243,6 +243,10 @@ start:
 	/* start the whole thing */
 	nrm_server_start(my_daemon.server);
 
+	nrm_log_info("exiting daemon\n");
+	/* wait a tiny bit before going out */
+	sleep(1);
+
 	/* teardown NRM */
 	nrm_string_decref(my_daemon.mytopic);
 	nrm_sensor_destroy(&my_daemon.mysensor);

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -244,8 +244,6 @@ start:
 	nrm_server_start(my_daemon.server);
 
 	nrm_log_info("exiting daemon\n");
-	/* wait a tiny bit before going out */
-	sleep(1);
 
 	/* teardown NRM */
 	nrm_string_decref(my_daemon.mytopic);

--- a/src/server.c
+++ b/src/server.c
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the libnrm project.
+ * For more info, see https://github.com/anlsys/libnrm
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+#include "config.h"
+
+#include "nrm.h"
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "internal/nrmi.h"
+#include "internal/messages.h"
+
+typedef int(nrm_server_event_callback_fn)(nrm_server_t *, int, int, void *, void *);
+
+/* we split the events between msg events and the rest to ease type conversion
+ * logic
+ */
+#define NRM_SERVER_EVENT_TYPE_ACK 0
+#define NRM_SERVER_EVENT_TYPE_LIST 1
+#define NRM_SERVER_EVENT_TYPE_ADD 2
+#define NRM_SERVER_EVENT_TYPE_REMOVE 3
+#define NRM_SERVER_EVENT_TYPE_EVENT 4
+#define NRM_SERVER_EVENT_TYPE_ACTUATE 5
+#define NRM_SERVER_EVENT_TYPE_MSG_MAX (6)
+
+#define NRM_SERVER_EVENT_TYPE_OTHER_START (100)
+#define NRM_SERVER_EVENT_TYPE_TIMER 100
+#define NRM_SERVER_EVENT_TYPE_SIGNAL 101
+#define NRM_SERVER_EVENT_TYPE_MAX (102)
+#define NRM_SERVER_EVENT_TYPE_COUNT (NRM_SERVER_EVENT_TYPE_MSG_MAX + \
+				     (NRM_SERVER_EVENT_TYPE_MAX - NRM_SERVER_EVENT_TYPE_OTHER_START))
+
+#define NRM_SERVER_OBJECT_TYPE_SLICE 0
+#define NRM_SERVER_OBJECT_TYPE_SENSOR 1
+#define NRM_SERVER_OBJECT_TYPE_SCOPE 2
+#define NRM_SERVER_OBJECT_TYPE_ACTUATOR 3
+#define NRM_SERVER_OBJECT_TYPE_MSG_MAX (4)
+
+#define NRM_SERVER_OBJECT_TYPE_OTHER_START (100)
+#define NRM_SERVER_OBJECT_TYPE_INT 100
+#define NRM_SERVER_OBJECT_TYPE_NONE 101
+#define NRM_SERVER_OBJECT_TYPE_STRING 102
+#define NRM_SERVER_OBJECT_TYPE_MAX (103)
+#define NRM_SERVER_OBJECT_TYPE_COUNT (NRM_SERVER_OBJECT_TYPE_MSG_MAX + \
+				     (NRM_SERVER_OBJECT_TYPE_MAX - NRM_SERVER_OBJECT_TYPE_OTHER_START))
+
+struct nrm_server_s {
+	nrm_role_t *role;
+	zloop_t *loop;
+	nrm_server_event_callback_fn *callbacks[NRM_SERVER_EVENT_TYPE_MAX];
+	void *user_arg;
+};
+
+
+/* indexed by msgtype */
+static const int nrm_server_event_msg_types[NRM_SERVER_EVENT_TYPE_MSG_MAX] = {
+	[NRM_MSG_TYPE_ACK]     = -1,
+	[NRM_MSG_TYPE_LIST]    =  NRM_SERVER_EVENT_TYPE_LIST,
+	[NRM_MSG_TYPE_ADD]     = NRM_SERVER_EVENT_TYPE_ADD,
+	[NRM_MSG_TYPE_REMOVE]  =  NRM_SERVER_EVENT_TYPE_REMOVE,
+	[NRM_MSG_TYPE_EVENT]   = NRM_SERVER_EVENT_TYPE_EVENT,
+	[NRM_MSG_TYPE_ACTUATE] = NRM_SERVER_EVENT_TYPE_ACTUATE,
+};
+
+static const int nrm_server_object_msg_types[NRM_SERVER_OBJECT_TYPE_MSG_MAX] = {
+	[NRM_MSG_TARGET_TYPE_SLICE] = NRM_SERVER_OBJECT_TYPE_SLICE,
+	[NRM_MSG_TARGET_TYPE_SENSOR] = NRM_SERVER_OBJECT_TYPE_SENSOR,
+	[NRM_MSG_TARGET_TYPE_SCOPE] = NRM_SERVER_OBJECT_TYPE_SCOPE,
+	[NRM_MSG_TARGET_TYPE_ACTUATOR] = NRM_SERVER_OBJECT_TYPE_ACTUATOR,
+};
+
+int nrm_server_msg2event(int type)
+{
+	int ret;
+	if (type < 0 || type >= NRM_SERVER_EVENT_TYPE_MSG_MAX)
+		return -NRM_EINVAL;
+	ret = nrm_server_event_msg_types[type];
+	if (ret == -1)
+		return -NRM_EINVAL;
+	/* the values of the two types are designed to match */
+	assert(ret == type);
+	return ret;
+}
+
+typedef int(*nrm_server_msg_converter_fn)(nrm_msg_t *, void **, int *);
+
+int nrm_server_msg_converter_list(nrm_msg_t *msg, void **arg, int *type)
+{
+	assert(msg->type == NRM_MSG_TYPE_LIST);
+	assert(msg->list->type < NRM_MSG_TARGET_TYPE_MAX);
+	*(intptr_t*)arg = nrm_server_object_msg_types[msg->list->type];
+	*type = NRM_SERVER_OBJECT_TYPE_INT;
+	return 0;
+}
+
+int nrm_server_msg_converter_add(nrm_msg_t *msg, void **arg, int *type)
+{
+	assert(msg->type == NRM_MSG_TYPE_ADD);
+	assert(msg->add->type < NRM_MSG_TARGET_TYPE_MAX);
+	nrm_actuator_t *a;
+	nrm_slice_t *sl;
+	switch(msg->add->type) {
+	case NRM_MSG_TARGET_TYPE_ACTUATOR:
+	a = nrm_actuator_create_frommsg(msg->add->actuator);
+	a->clientid = nrm_uuid_create_fromchar(nrm_uuid_to_char(clientid));
+	*type = NRM_SERVER_OBJECT_TYPE_ACTUATOR;
+	*arg = a;
+	break;
+	case NRM_MSG_TARGET_TYPE_SLICE:
+	sl = nrm_slice_create(msg->add->slice->uuid);
+	*type = NRM_SERVER_OBJECT_TYPE_SLICE;
+	*arg = sl;
+	}
+	return 0;
+}
+
+static const nrm_server_msg_converter_fn nrm_server_msg_converters[] = {
+	[NRM_SERVER_EVENT_TYPE_LIST] = nrm_server_msg_converter_list,
+	[NRM_SERVER_EVENT_TYPE_ADD] = nrm_server_msg_converter_add,
+};
+
+int nrm_server_role_callback(zloop_t *loop, zsock_t *socket, void *arg)
+{
+	(void)loop;
+	(void)socket;
+	nrm_server_t *self = (nrm_server_t *)arg;
+	nrm_log_info("event callback: message\n");
+	nrm_msg_t *msg, *ret;
+	nrm_uuid_t *uuid;
+	nrm_log_debug("receiving message...\n");
+	msg = nrm_role_recv(self->role, &uuid);
+	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
+
+	int event_type = nrm_server_msg2event(msg->type);
+	if (self->callbacks[event_type] == NULL) {
+		nrm_log_debug("missing callback for %d\n");
+		return 0;
+	}
+
+	void *arg1;
+	int object_type;
+	int err = nrm_server_msg2params(msg, &arg1, &object_type);
+	if (!err) {
+		nrm_log_error("failed to convert message to callback params\n");
+		return -1;
+	}
+
+	nrm_server_event_callback_fn cb = self->callbacks[event_type];
+	err = cb(self, event_type, object_type, arg1, self->user_arg);
+	return err;
+}
+
+int nrm_server_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void
+				*arg)
+{
+	(void)loop;
+	nrm_server_t *self = (nrm_server_t *)arg;
+	struct signalfd_siginfo fdsi;
+	ssize_t s = read(poller->fd, &fdsi, sizeof(struct signalfd_siginfo));
+	assert(s == sizeof(struct signalfd_siginfo));
+	int signalid = fdsi.ssi_signo;
+	nrm_log_debug("caught signal %d\n", signalid);
+
+	/* we default to exit */
+	int ret = -1;
+	nrm_server_event_callback_fn cb = self->callbacks[NRM_SERVER_EVENT_SIGNAL];
+	if (cb != NULL)
+		ret = cb(self, NRM_SERVER_EVENT_TYPE_SIGNAL,
+		   NRM_SERVER_OBJECT_TYPE_INT, &signalid, self->user_arg);
+	return ret;
+}
+
+int nrm_server_timer_callback(zloop_t *loop, int timerid, void *arg)
+{
+	(void)loop;
+	(void)timerid;
+	nrm_server_t *self = (nrm_server_t *)arg;
+
+	int ret = 0;
+	nrm_server_event_callback_fn cb =
+		self->callbacks[NRM_SERVER_EVENT_TYPE_TIMER];
+	if (cb != NULL)
+		ret = cb(self, NRM_SERVER_EVENT_TYPE_TIMER,
+			 NRM_SERVER_OBJECT_NONE, NULL, self->user_arg);
+	return ret;
+}
+
+
+int nrm_server_create(nrm_server_t **server, const char *uri, int pub_port, int
+		      rpc_port)
+{
+	if (server == NULL || uri == NULL)
+		return -NRM_EINVAL;
+
+	nrm_server_t *ret = calloc(1, sizeof(nrm_server_t));
+	if (ret == NULL)
+		return -NRM_ENOMEM;
+
+	ret->role = nrm_role_controller_create_fromparams(uri, pub_port,
+							  rpc_port);
+	if (ret->role == NULL)
+		return -NRM_EINVAL;
+	ret->loop = zloop_new();
+	assert(ret->loop != NULL);
+
+	/* we always setup signal handling and controller callback */
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGINT);
+	sfd = signalfd(-1, &sigmask, 0);
+	assert(sfd != -1);
+	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN};
+	zloop_poller(ret->loop, &signal_poller, nrm_server_signal_callback, NULL);
+
+	nrm_role_controller_register_recvcallback(ret->role, ret->loop,
+						  nrm_server_role_callback,
+						  ret);
+	return ret;
+}
+
+int nrm_server_settimer(nrm_server_t *server, int millisecs)
+{
+	if (server == NULL)
+		return -NRM_EINVAL;
+
+	zloop_timer(server->loop, millisecs, 0, nrm_server_timer_callback,
+		    server);
+	return 0;
+}
+
+int nrm_server_publish(nrm_server_t *server, nrm_string_t topic,
+		       nrm_sensor_t *sensor,
+		       nrm_scope_t *scope,
+		       double value)
+{
+	if (server == NULL || topic == NULL || sensor == NULL || scope == NULL)
+		return -NRM_EINVAL;
+
+	nrm_msg_t *msg = nrm_msg_create();
+	nrm_msg_fill(msg, NRM_MSG_TYPE_EVENT);
+	nrm_msg_set_event(msg, now, sensor->uuid, scope, 1.0);
+	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
+	return nrm_role_pub(server->role, topic, msg);
+}
+
+int nrm_server_start(nrm_server_t *server)
+{
+	if (server == NULL)
+		return -NRM_EINVAL;
+
+	return zloop_start(server->start);
+}
+
+void nrm_server_destroy(nrm_server_t **server)
+{
+	if (server == NULL || *server == NULL)
+		return;
+	nrm_server_t *s = *server;
+	zloop_destroy(&server->loop);
+	nrm_role_destroy(&server->role);
+	free(s);
+	*server = NULL;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -15,29 +15,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/signalfd.h>
 
 #include "internal/nrmi.h"
 #include "internal/messages.h"
 
-typedef int(nrm_server_event_callback_fn)(nrm_server_t *, int, int, void *, void *);
+struct nrm_server_user_callbacks_s {
+	int(*list)(nrm_server_t *, nrm_uuid_t *, int, void *);
+	int(*add)(nrm_server_t *, nrm_uuid_t *, int, void *, void *);
+	int(*remove)(nrm_server_t *, nrm_uuid_t *, int, nrm_string_t, void *);
+	int(*event)(nrm_server_t *, nrm_uuid_t *, nrm_string_t, nrm_scope_t *,
+		    nrm_time_t, double value, void *);
+	int(*actuate)(nrm_server_t *, nrm_uuid_t *, nrm_string_t, double value,
+		      void *);
+	int(*signal)(nrm_server_t *, int, void *);
+	int(*timer)(nrm_server_t *, void *);
+};
 
-/* we split the events between msg events and the rest to ease type conversion
- * logic
- */
-#define NRM_SERVER_EVENT_TYPE_ACK 0
-#define NRM_SERVER_EVENT_TYPE_LIST 1
-#define NRM_SERVER_EVENT_TYPE_ADD 2
-#define NRM_SERVER_EVENT_TYPE_REMOVE 3
-#define NRM_SERVER_EVENT_TYPE_EVENT 4
-#define NRM_SERVER_EVENT_TYPE_ACTUATE 5
-#define NRM_SERVER_EVENT_TYPE_MSG_MAX (6)
+typedef struct nrm_server_user_callbacks_s nrm_server_user_callbacks_t;
 
-#define NRM_SERVER_EVENT_TYPE_OTHER_START (100)
-#define NRM_SERVER_EVENT_TYPE_TIMER 100
-#define NRM_SERVER_EVENT_TYPE_SIGNAL 101
-#define NRM_SERVER_EVENT_TYPE_MAX (102)
-#define NRM_SERVER_EVENT_TYPE_COUNT (NRM_SERVER_EVENT_TYPE_MSG_MAX + \
-				     (NRM_SERVER_EVENT_TYPE_MAX - NRM_SERVER_EVENT_TYPE_OTHER_START))
 
 #define NRM_SERVER_OBJECT_TYPE_SLICE 0
 #define NRM_SERVER_OBJECT_TYPE_SENSOR 1
@@ -56,20 +52,10 @@ typedef int(nrm_server_event_callback_fn)(nrm_server_t *, int, int, void *, void
 struct nrm_server_s {
 	nrm_role_t *role;
 	zloop_t *loop;
-	nrm_server_event_callback_fn *callbacks[NRM_SERVER_EVENT_TYPE_MAX];
+	nrm_server_user_callback_t callbacks;
 	void *user_arg;
 };
 
-
-/* indexed by msgtype */
-static const int nrm_server_event_msg_types[NRM_SERVER_EVENT_TYPE_MSG_MAX] = {
-	[NRM_MSG_TYPE_ACK]     = -1,
-	[NRM_MSG_TYPE_LIST]    =  NRM_SERVER_EVENT_TYPE_LIST,
-	[NRM_MSG_TYPE_ADD]     = NRM_SERVER_EVENT_TYPE_ADD,
-	[NRM_MSG_TYPE_REMOVE]  =  NRM_SERVER_EVENT_TYPE_REMOVE,
-	[NRM_MSG_TYPE_EVENT]   = NRM_SERVER_EVENT_TYPE_EVENT,
-	[NRM_MSG_TYPE_ACTUATE] = NRM_SERVER_EVENT_TYPE_ACTUATE,
-};
 
 static const int nrm_server_object_msg_types[NRM_SERVER_OBJECT_TYPE_MSG_MAX] = {
 	[NRM_MSG_TARGET_TYPE_SLICE] = NRM_SERVER_OBJECT_TYPE_SLICE,
@@ -78,23 +64,9 @@ static const int nrm_server_object_msg_types[NRM_SERVER_OBJECT_TYPE_MSG_MAX] = {
 	[NRM_MSG_TARGET_TYPE_ACTUATOR] = NRM_SERVER_OBJECT_TYPE_ACTUATOR,
 };
 
-int nrm_server_msg2event(int type)
+int nrm_server_msg_converter_list(nrm_uuid_t *uuid, nrm_msg_t *msg, void **arg, int *type)
 {
-	int ret;
-	if (type < 0 || type >= NRM_SERVER_EVENT_TYPE_MSG_MAX)
-		return -NRM_EINVAL;
-	ret = nrm_server_event_msg_types[type];
-	if (ret == -1)
-		return -NRM_EINVAL;
-	/* the values of the two types are designed to match */
-	assert(ret == type);
-	return ret;
-}
-
-typedef int(*nrm_server_msg_converter_fn)(nrm_msg_t *, void **, int *);
-
-int nrm_server_msg_converter_list(nrm_msg_t *msg, void **arg, int *type)
-{
+	(void)uuid;
 	assert(msg->type == NRM_MSG_TYPE_LIST);
 	assert(msg->list->type < NRM_MSG_TARGET_TYPE_MAX);
 	*(intptr_t*)arg = nrm_server_object_msg_types[msg->list->type];
@@ -102,31 +74,82 @@ int nrm_server_msg_converter_list(nrm_msg_t *msg, void **arg, int *type)
 	return 0;
 }
 
-int nrm_server_msg_converter_add(nrm_msg_t *msg, void **arg, int *type)
+int nrm_server_msg_converter_add(nrm_uuid_t *uuid, nrm_msg_t *msg, void **arg, int *type)
 {
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type < NRM_MSG_TARGET_TYPE_MAX);
 	nrm_actuator_t *a;
 	nrm_slice_t *sl;
+	nrm_sensor_t *se;
+	nrm_scope_t *sc;
 	switch(msg->add->type) {
 	case NRM_MSG_TARGET_TYPE_ACTUATOR:
-	a = nrm_actuator_create_frommsg(msg->add->actuator);
-	a->clientid = nrm_uuid_create_fromchar(nrm_uuid_to_char(clientid));
-	*type = NRM_SERVER_OBJECT_TYPE_ACTUATOR;
-	*arg = a;
-	break;
+		a = nrm_actuator_create_frommsg(msg->add->actuator);
+		a->clientid = nrm_uuid_create_fromchar(nrm_uuid_to_char(uuid));
+		*type = NRM_SERVER_OBJECT_TYPE_ACTUATOR;
+		*arg = a;
+		break;
 	case NRM_MSG_TARGET_TYPE_SLICE:
-	sl = nrm_slice_create(msg->add->slice->uuid);
-	*type = NRM_SERVER_OBJECT_TYPE_SLICE;
-	*arg = sl;
+		sl = nrm_slice_create_frommsg(msg->add->slice);
+		*type = NRM_SERVER_OBJECT_TYPE_SLICE;
+		*arg = sl;
+		break;
+	case NRM_MSG_TARGET_TYPE_SENSOR:
+		se = nrm_sensor_create_frommsg(msg->add->sensor);
+		*type = NRM_SERVER_OBJECT_TYPE_SENSOR;
+		*arg = se;
+		break;
+	case NRM_MSG_TARGET_TYPE_SCOPE:
+		sc = nrm_scope_create_frommsg(msg->add->scope);
+		*type = NRM_SERVER_OBJECT_TYPE_SCOPE;
+		*arg = sc;
+		break;
+	default:
+		nrm_log_error("wrong message type: %d\n", msg->add->type);
+		assert(0);
 	}
 	return 0;
 }
 
-static const nrm_server_msg_converter_fn nrm_server_msg_converters[] = {
-	[NRM_SERVER_EVENT_TYPE_LIST] = nrm_server_msg_converter_list,
-	[NRM_SERVER_EVENT_TYPE_ADD] = nrm_server_msg_converter_add,
-};
+int nrm_server_msg_converter_remove(nrm_uuid_t *uuid, nrm_msg_t *msg, void **arg, int *type)
+{
+	assert(msg->type == NRM_MSG_TYPE_REMOVE);
+	assert(msg->remove->type < NRM_MSG_TARGET_TYPE_MAX);
+	nrm_string_t uuid;
+
+	return 0;
+}
+
+int nrm_server_msg_converter_event(nrm_uuid_t *uuid, nrm_msg_t *msg, void **arg, int *type)
+{
+	return 0;
+}
+
+int nrm_server_msg_converter_actuate(nrm_uuid_t *uuid, nrm_msg_t *msg, void **arg, int *type)
+{
+	return 0;
+}
+
+
+int nrm_server_list_callback(nrm_server_t *self, nrm_uuid_t *clientid,
+			     nrm_msg_list_t *msg)
+{
+	(void)uuid;
+	assert(msg->type == NRM_MSG_TYPE_LIST);
+	int type = nrm_server_msg_types[msg->type];
+	int ret = self->callbacks->list(self, clientid, type,
+					self->user_arg);
+	if (ret == 0) {
+		/* TODO: callback should fill out a vector of results */
+	} else {
+		/* TODO: nack message */	
+	}
+	/* we don't return an error here unless it's a failure of the server
+	 * code itself */
+	return 0;
+}
+
+
 
 int nrm_server_role_callback(zloop_t *loop, zsock_t *socket, void *arg)
 {
@@ -134,28 +157,34 @@ int nrm_server_role_callback(zloop_t *loop, zsock_t *socket, void *arg)
 	(void)socket;
 	nrm_server_t *self = (nrm_server_t *)arg;
 	nrm_log_info("event callback: message\n");
-	nrm_msg_t *msg, *ret;
+	nrm_msg_t *msg;
 	nrm_uuid_t *uuid;
 	nrm_log_debug("receiving message...\n");
 	msg = nrm_role_recv(self->role, &uuid);
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
-	int event_type = nrm_server_msg2event(msg->type);
-	if (self->callbacks[event_type] == NULL) {
-		nrm_log_debug("missing callback for %d\n");
-		return 0;
+	int err;
+	switch(msg->type) {
+	case NRM_MSG_TYPE_ACTUATE:
+		err = nrm_server_actuate_callback(self, uuid, msg->actuate);
+		break;
+	case NRM_MSG_TYPE_LIST:
+		err = nrm_server_list_callback(self, uuid, msg->list);
+		break;
+	case NRM_MSG_TYPE_ADD:
+		err = nrm_server_add_callback(self, uuid, msg->add);
+		break;
+	case NRM_MSG_TYPE_EVENT:
+		err = nrm_server_event_callback(self, uuid, msg->event);
+		break;
+	case NRM_MSG_TYPE_REMOVE:
+		err = nrm_server_remove_callback(self, uuid, msg->remove);
+		break;
+	default:
+		nrm_log_error("message type not handled\n");
+		return -NRM_EINVAL;
 	}
-
-	void *arg1;
-	int object_type;
-	int err = nrm_server_msg2params(msg, &arg1, &object_type);
-	if (!err) {
-		nrm_log_error("failed to convert message to callback params\n");
-		return -1;
-	}
-
-	nrm_server_event_callback_fn cb = self->callbacks[event_type];
-	err = cb(self, event_type, object_type, arg1, self->user_arg);
+	nrm_msg_destroy(&msg);
 	return err;
 }
 
@@ -172,10 +201,8 @@ int nrm_server_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void
 
 	/* we default to exit */
 	int ret = -1;
-	nrm_server_event_callback_fn cb = self->callbacks[NRM_SERVER_EVENT_SIGNAL];
-	if (cb != NULL)
-		ret = cb(self, NRM_SERVER_EVENT_TYPE_SIGNAL,
-		   NRM_SERVER_OBJECT_TYPE_INT, &signalid, self->user_arg);
+	if (self->callbacks->signal != NULL)
+		ret = self->callbacks->signal(self, signalid, self->user_arg);
 	return ret;
 }
 
@@ -186,11 +213,8 @@ int nrm_server_timer_callback(zloop_t *loop, int timerid, void *arg)
 	nrm_server_t *self = (nrm_server_t *)arg;
 
 	int ret = 0;
-	nrm_server_event_callback_fn cb =
-		self->callbacks[NRM_SERVER_EVENT_TYPE_TIMER];
-	if (cb != NULL)
-		ret = cb(self, NRM_SERVER_EVENT_TYPE_TIMER,
-			 NRM_SERVER_OBJECT_NONE, NULL, self->user_arg);
+	if (self->callbacks->timer != NULL)
+		ret = self->callbacks->timer(self, self->user_arg);
 	return ret;
 }
 
@@ -216,15 +240,16 @@ int nrm_server_create(nrm_server_t **server, const char *uri, int pub_port, int
 	sigset_t sigmask;
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGINT);
-	sfd = signalfd(-1, &sigmask, 0);
+	int sfd = signalfd(-1, &sigmask, 0);
 	assert(sfd != -1);
-	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN};
+	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN, 0};
 	zloop_poller(ret->loop, &signal_poller, nrm_server_signal_callback, NULL);
 
 	nrm_role_controller_register_recvcallback(ret->role, ret->loop,
 						  nrm_server_role_callback,
 						  ret);
-	return ret;
+	*server = ret;
+	return 0;
 }
 
 int nrm_server_settimer(nrm_server_t *server, int millisecs)
@@ -238,7 +263,7 @@ int nrm_server_settimer(nrm_server_t *server, int millisecs)
 }
 
 int nrm_server_publish(nrm_server_t *server, nrm_string_t topic,
-		       nrm_sensor_t *sensor,
+		       nrm_time_t now, nrm_sensor_t *sensor,
 		       nrm_scope_t *scope,
 		       double value)
 {
@@ -247,7 +272,7 @@ int nrm_server_publish(nrm_server_t *server, nrm_string_t topic,
 
 	nrm_msg_t *msg = nrm_msg_create();
 	nrm_msg_fill(msg, NRM_MSG_TYPE_EVENT);
-	nrm_msg_set_event(msg, now, sensor->uuid, scope, 1.0);
+	nrm_msg_set_event(msg, now, sensor->uuid, scope, value);
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 	return nrm_role_pub(server->role, topic, msg);
 }
@@ -257,7 +282,7 @@ int nrm_server_start(nrm_server_t *server)
 	if (server == NULL)
 		return -NRM_EINVAL;
 
-	return zloop_start(server->start);
+	return zloop_start(server->loop);
 }
 
 void nrm_server_destroy(nrm_server_t **server)
@@ -265,8 +290,8 @@ void nrm_server_destroy(nrm_server_t **server)
 	if (server == NULL || *server == NULL)
 		return;
 	nrm_server_t *s = *server;
-	zloop_destroy(&server->loop);
-	nrm_role_destroy(&server->role);
+	zloop_destroy(&s->loop);
+	nrm_role_destroy(&s->role);
 	free(s);
 	*server = NULL;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -24,6 +24,110 @@ nrm_state_t *nrm_state_create()
 	return ret;
 }
 
+int nrm_state_remove_actuator(nrm_state_t *state, const char *uuid)
+{
+	nrm_actuator_t *actuator = NULL;
+	nrm_string_t id = nrm_string_fromchar(uuid);
+	nrm_hash_remove(&state->actuators, id, (void *)&actuator);
+	nrm_actuator_destroy(&actuator);
+	nrm_string_decref(id);
+	return 0;
+}
+
+int nrm_state_remove_scope(nrm_state_t *state, const char *uuid)
+{
+	nrm_scope_t *scope = NULL;
+	nrm_string_t id = nrm_string_fromchar(uuid);
+	nrm_hash_remove(&state->scopes, id, (void *)&scope);
+	nrm_scope_destroy(scope);
+	nrm_string_decref(id);
+	return 0;
+}
+
+int nrm_state_remove_sensor(nrm_state_t *state, const char *uuid)
+{
+	nrm_sensor_t *sensor = NULL;
+	nrm_string_t id = nrm_string_fromchar(uuid);
+	nrm_hash_remove(&state->sensors, id, (void *)&sensor);
+	nrm_sensor_destroy(&sensor);
+	nrm_string_decref(id);
+	return 0;
+}
+
+int nrm_state_remove_slice(nrm_state_t *state, const char *uuid)
+{
+	nrm_slice_t *slice = NULL;
+	nrm_string_t id = nrm_string_fromchar(uuid);
+	nrm_hash_remove(&state->slices, id, (void *)&slice);
+	nrm_slice_destroy(&slice);
+	nrm_string_decref(id);
+	return 0;
+}
+
+int nrm_state_list_actuators(nrm_state_t *state, nrm_vector_t *vec)
+{
+	nrm_hash_foreach(state->actuators, iter)
+	{
+		nrm_actuator_t *actuator = nrm_hash_iterator_get(iter);
+		nrm_vector_push_back(vec, actuator);
+	}
+	return 0;
+}
+
+int nrm_state_list_scopes(nrm_state_t *state, nrm_vector_t *vec)
+{
+	nrm_hash_foreach(state->scopes, iter)
+	{
+		nrm_scope_t *scope = nrm_hash_iterator_get(iter);
+		nrm_vector_push_back(vec, scope);
+	}
+	return 0;
+}
+
+int nrm_state_list_sensors(nrm_state_t *state, nrm_vector_t *vec)
+{
+	nrm_hash_foreach(state->sensors, iter)
+	{
+		nrm_sensor_t *sensor = nrm_hash_iterator_get(iter);
+		nrm_vector_push_back(vec, sensor);
+	}
+	return 0;
+}
+
+int nrm_state_list_slices(nrm_state_t *state, nrm_vector_t *vec)
+{
+	nrm_hash_foreach(state->slices, iter)
+	{
+		nrm_slice_t *slice = nrm_hash_iterator_get(iter);
+		nrm_vector_push_back(vec, slice);
+	}
+	return 0;
+}
+
+int nrm_state_add_actuator(nrm_state_t *state, nrm_actuator_t *actuator)
+{
+	nrm_hash_add(&state->actuators, actuator->uuid, actuator);
+	return 0;
+}
+
+int nrm_state_add_scope(nrm_state_t *state, nrm_scope_t *scope)
+{
+	nrm_hash_add(&state->scopes, scope->uuid, scope);
+	return 0;
+}
+
+int nrm_state_add_sensor(nrm_state_t *state, nrm_sensor_t *sensor)
+{
+	nrm_hash_add(&state->sensors, sensor->uuid, sensor);
+	return 0;
+}
+
+int nrm_state_add_slice(nrm_state_t *state, nrm_slice_t *slice)
+{
+	nrm_hash_add(&state->slices, slice->uuid, slice);
+	return 0;
+}
+
 void nrm_state_destroy(nrm_state_t **state)
 {
 	if (state == NULL || *state == NULL)

--- a/tests/cli/bats-driver.sh.in
+++ b/tests/cli/bats-driver.sh.in
@@ -2,4 +2,4 @@
 # none of our bats tests should take more than a few seconds
 BATS_TEST_TIMEOUT=10
 PATH=@abs_top_builddir@:$PATH
-@BATS@ $@
+@BATS@ -x --verbose-run $@

--- a/tests/cli/bats-driver.sh.in
+++ b/tests/cli/bats-driver.sh.in
@@ -1,3 +1,5 @@
 #!/bin/sh
+# none of our bats tests should take more than a few seconds
+BATS_TEST_TIMEOUT=10
 PATH=@abs_top_builddir@:$PATH
 @BATS@ $@

--- a/tests/cli/bats-driver.sh.in
+++ b/tests/cli/bats-driver.sh.in
@@ -2,4 +2,4 @@
 # none of our bats tests should take more than a few seconds
 BATS_TEST_TIMEOUT=10
 PATH=@abs_top_builddir@:$PATH
-@BATS@ -x --verbose-run $@
+@BATS@ $@

--- a/tests/cli/nrmc.bats
+++ b/tests/cli/nrmc.bats
@@ -77,6 +77,26 @@ setup() {
 	[ "$status" -eq 0 ]
 }
 
+@test "list slices" {
+	# can we list slices
+	run nrmc -q list-slices
+	[ "$status" -eq 0 ]
+	# print the output in case of errors
+	echo "$output"
+	# actual check: just make sure that it's valid json
+	echo "$output" | jq
+}
+
+@test "list scopes" {
+	# can we list scopes
+	run nrmc -q list-scopes
+	[ "$status" -eq 0 ]
+	# print the output in case of errors
+	echo "$output"
+	# actual check: just make sure that it's valid json
+	echo "$output" | jq
+}
+
 teardown() {
 	kill $NRMD_DUMMY_PID
 	kill $NRMD_PID

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -6,9 +6,9 @@
 }
 
 @test "exit works" {
-	nrmd &>/dev/null 3>&- &
+	timeout 3 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
-	sleep 0.1
+	sleep 0.5
 	run nrmc -q exit
 	[ "$status" -eq 0 ]
 	wait $NRMD_PID

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -6,11 +6,11 @@
 }
 
 @test "exit works" {
-	timeout 10 nrmd &>/dev/null 3>&- &
+	nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
-	sleep 1
-	timeout 5 nrmc exit
-	[ "$?" -eq 0 ]
+	sleep 0.1
+	# completely ignore any exit status on nrmc
+	run timeout 1 nrmc exit
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]
 }

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -6,10 +6,10 @@
 }
 
 @test "exit works" {
-	timeout 5 nrmd &>/dev/null 3>&- &
+	timeout 10 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
 	sleep 1
-	timeout 3 nrmc exit
+	timeout 5 nrmc exit
 	[ "$?" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -9,7 +9,7 @@
 	timeout 5 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
 	sleep 1
-	timeout 2 nrmc exit
+	timeout 3 nrmc exit
 	[ "$?" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -6,10 +6,10 @@
 }
 
 @test "exit works" {
-	timeout 3 nrmd &>/dev/null 3>&- &
+	timeout 5 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
-	sleep 0.5
-	run timeout 1 nrmc -q exit
+	sleep 1
+	run timeout 2 nrmc -q exit
 	[ "$status" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -9,7 +9,7 @@
 	timeout 3 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
 	sleep 0.5
-	run nrmc -q exit
+	run timeout 1 nrmc -q exit
 	[ "$status" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -1,5 +1,16 @@
 #!/usr/bin/env bats
+# vim: set ft=bash:
 
 @test "--version works" {
 	nrmd --version
+}
+
+@test "exit works" {
+	nrmd &>/dev/null 3>&- &
+	NRMD_PID=$!
+	sleep 0.1
+	run nrmc -q exit
+	[ "$status" -eq 0 ]
+	wait $NRMD_PID
+	[ "$?" -eq 0 ]
 }

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -9,8 +9,8 @@
 	timeout 5 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
 	sleep 1
-	run timeout 2 nrmc exit
-	[ "$status" -eq 0 ]
+	timeout 2 nrmc exit
+	[ "$?" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]
 }

--- a/tests/cli/nrmd.bats
+++ b/tests/cli/nrmd.bats
@@ -9,7 +9,7 @@
 	timeout 5 nrmd &>/dev/null 3>&- &
 	NRMD_PID=$!
 	sleep 1
-	run timeout 2 nrmc -q exit
+	run timeout 2 nrmc exit
 	[ "$status" -eq 0 ]
 	wait $NRMD_PID
 	[ "$?" -eq 0 ]


### PR DESCRIPTION
Introduce a server object, abstracting over most of the callback and msg parsing logic away from the nrmd code.

Closes #25.

Some background on the PR:

First attempt tried to use generic callbacks with a custom parser for all arguments,
didn't work out at all. Trying to keep the callbacks generic
and parsing messages on the fly result in too many untyped pointers
being passed around, for very limited value.

Second Attempt tried to use user-defined callbacks per type of msg, and parse the messages properly
before calling the user code. Resulted in a lot of duplication between user-level code and server logic.

We ended up with a system where we centralize the state into the server, and only have callbacks for
control/actuate/timer. I'm not exactly happy with the actuation logic at this point, but it is better than
before.

I tried to use bats to test as many things as possible, but there's always the possibility that I missed something.