### PR TITLE
[fix] remove public nrm_msg_t definition

### DIFF
--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -49,6 +49,7 @@ typedef Nrm__ActuatorList nrm_msg_actuatorlist_t;
 typedef Nrm__Add nrm_msg_add_t;
 typedef Nrm__Event nrm_msg_event_t;
 typedef Nrm__List nrm_msg_list_t;
+typedef Nrm__Message nrm_msg_t;
 typedef Nrm__Remove nrm_msg_remove_t;
 typedef Nrm__Scope nrm_msg_scope_t;
 typedef Nrm__ScopeList nrm_msg_scopelist_t;
@@ -74,6 +75,7 @@ typedef Nrm__SliceList nrm_msg_slicelist_t;
 
 nrm_msg_t *nrm_msg_create(void);
 void nrm_msg_destroy(nrm_msg_t **msg);
+void nrm_log_printmsg(int level, nrm_msg_t *msg);
 
 int nrm_msg_fill(nrm_msg_t *msg, int type);
 int nrm_msg_set_event(nrm_msg_t *msg,

--- a/include/internal/nrmi.h
+++ b/include/internal/nrmi.h
@@ -85,8 +85,6 @@ struct nrm_scope {
 	struct nrm_bitmap maps[NRM_SCOPE_TYPE_MAX];
 };
 
-void nrm_log_printmsg(int level, nrm_msg_t *msg);
-
 int nrm_actuator_from_json(nrm_actuator_t *, json_t *);
 int nrm_bitmap_from_json(nrm_bitmap_t *, json_t *);
 int nrm_scope_from_json(nrm_scope_t *, json_t *);

--- a/include/internal/roles.h
+++ b/include/internal/roles.h
@@ -22,6 +22,10 @@ extern "C" {
  * Global definitions
  ******************************************************************************/
 
+typedef struct nrm_role_s nrm_role_t;
+typedef int(nrm_role_sub_callback_fn)(nrm_msg_t *msg, void *arg);
+typedef int(nrm_role_cmd_callback_fn)(nrm_msg_t *msg, void *arg);
+
 struct nrm_role_data;
 
 struct nrm_role_ops {
@@ -92,6 +96,24 @@ extern struct nrm_role_ops nrm_role_controller_ops;
 nrm_role_t *nrm_role_client_create_fromparams(const char *, int, int);
 
 extern struct nrm_role_ops nrm_role_client_ops;
+
+/*******************************************************************************
+ * Public API:
+ * common API across all roles
+ ******************************************************************************/
+
+int nrm_role_send(const nrm_role_t *role, nrm_msg_t *msg, nrm_uuid_t *to);
+nrm_msg_t *nrm_role_recv(const nrm_role_t *role, nrm_uuid_t **from);
+int nrm_role_pub(const nrm_role_t *role, nrm_string_t topic, nrm_msg_t *msg);
+int nrm_role_register_sub_cb(const nrm_role_t *role,
+                             nrm_role_sub_callback_fn *fn,
+                             void *arg);
+int nrm_role_register_cmd_cb(const nrm_role_t *role,
+                             nrm_role_cmd_callback_fn *fn,
+                             void *arg);
+int nrm_role_sub(const nrm_role_t *role, nrm_string_t topic);
+
+void nrm_role_destroy(nrm_role_t **);
 
 #ifdef __cplusplus
 }

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -114,15 +114,6 @@ int nrm_log_setlevel(int level);
 	nrm_log_printf(NRM_LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 
 /*******************************************************************************
- * NRM Messages
- * Messages being transmitted between nrm components
- ******************************************************************************/
-
-typedef struct _Nrm__Message nrm_msg_t;
-
-void nrm_msg_destroy(nrm_msg_t **msg);
-
-/*******************************************************************************
  * Actuator: something capable of actions on the system
  ******************************************************************************/
 
@@ -402,38 +393,6 @@ int nrm_client_start_actuate_listener(const nrm_client_t *client);
  * exits.
  */
 void nrm_client_destroy(nrm_client_t **client);
-
-/*******************************************************************************
- * NRM Role API
- * A "role" is a set of features of NRM that a client of this library is using.
- * A typical role is a sensor, or an actuator, or something monitoring sensor
- * messages and so on.
- * Behind each role is an event loop and a helper thread, related to its actions
- * in the communication infrastructure of the NRM.
- ******************************************************************************/
-
-typedef struct nrm_role_s nrm_role_t;
-typedef int(nrm_role_sub_callback_fn)(nrm_msg_t *msg, void *arg);
-typedef int(nrm_role_cmd_callback_fn)(nrm_msg_t *msg, void *arg);
-
-nrm_role_t *nrm_role_monitor_create_fromenv();
-
-nrm_role_t *nrm_role_sensor_create_fromenv(const char *sensor_name);
-
-nrm_role_t *nrm_role_client_create_fromparams(const char *, int, int);
-
-int nrm_role_send(const nrm_role_t *role, nrm_msg_t *msg, nrm_uuid_t *to);
-nrm_msg_t *nrm_role_recv(const nrm_role_t *role, nrm_uuid_t **from);
-int nrm_role_pub(const nrm_role_t *role, nrm_string_t topic, nrm_msg_t *msg);
-int nrm_role_register_sub_cb(const nrm_role_t *role,
-                             nrm_role_sub_callback_fn *fn,
-                             void *arg);
-int nrm_role_register_cmd_cb(const nrm_role_t *role,
-                             nrm_role_cmd_callback_fn *fn,
-                             void *arg);
-int nrm_role_sub(const nrm_role_t *role, nrm_string_t topic);
-
-void nrm_role_destroy(nrm_role_t **);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Needed to ensure protobuf-c compatibility between v1.3.3 and v.1.4.0