### PR TITLE
[fix] add fast strlen for nrm_string_t

### DIFF
--- a/include/nrm/utils/strings.h
+++ b/include/nrm/utils/strings.h
@@ -22,4 +22,6 @@ void nrm_string_decref(nrm_string_t s);
 
 int nrm_string_cmp(const nrm_string_t, const nrm_string_t);
 
+size_t nrm_string_strlen(const nrm_string_t);
+
 #endif

--- a/src/eventbase.c
+++ b/src/eventbase.c
@@ -26,7 +26,6 @@ struct nrm_eventbase_s {
 	size_t maxperiods;
 	struct nrm_sensor2scope_s *hash;
 };
-typedef struct nrm_eventbase_s nrm_eventbase_t;
 
 /* events, as stored in one of the ringbuffers */
 struct nrm_event_s {
@@ -120,14 +119,14 @@ struct nrm_sensor2scope_s *nrm_eventbase_add_sensor(nrm_eventbase_t *eb,
 	s->uuid = sensor_uuid;
 	nrm_string_incref(sensor_uuid);
 	s->list = NULL;
-	HASH_ADD_KEYPTR(hh, eb->hash, s->uuid, strlen(s->uuid), s);
+	HASH_ADD_KEYPTR(hh, eb->hash, s->uuid, nrm_string_strlen(s->uuid), s);
 	return s;
 }
 
-int nrm_eventbase_remove_sensor(nrm_eventbase_t *eb, nrm_string_t *sensor_uuid)
+int nrm_eventbase_remove_sensor(nrm_eventbase_t *eb, nrm_string_t sensor_uuid)
 {
 	struct nrm_sensor2scope_s *s;
-	HASH_FIND_STR(eb->hash, sensor_uuid, s);
+	HASH_FIND(hh, eb->hash, sensor_uuid, nrm_string_strlen(sensor_uuid), s);
 	if (s != NULL) {
 		struct nrm_scope2ring_s *elt, *tmp;
 		DL_FOREACH_SAFE(s->list, elt, tmp)
@@ -151,7 +150,7 @@ int nrm_eventbase_push_event(nrm_eventbase_t *eb,
 {
 	struct nrm_sensor2scope_s *s2s;
 	struct nrm_scope2ring_s *s2r;
-	HASH_FIND_STR(eb->hash, sensor_uuid, s2s);
+	HASH_FIND(hh, eb->hash, sensor_uuid, nrm_string_strlen(sensor_uuid), s2s);
 	if (s2s == NULL)
 		s2s = nrm_eventbase_add_sensor(eb, sensor_uuid);
 	DL_FOREACH(s2s->list, s2r)
@@ -175,7 +174,7 @@ int nrm_eventbase_last_value(nrm_eventbase_t *eb,
 {
 	struct nrm_sensor2scope_s *s2s;
 	struct nrm_scope2ring_s *s2r;
-	HASH_FIND_STR(eb->hash, sensor_uuid, s2s);
+	HASH_FIND(hh, eb->hash, sensor_uuid, nrm_string_strlen(sensor_uuid), s2s);
 	if (s2s == NULL) {
 		*value = 0.0;
 		return -NRM_EINVAL;

--- a/src/utils/hashes.c
+++ b/src/utils/hashes.c
@@ -32,7 +32,7 @@ static int nrm_hash_create_element(nrm_hash_t **element)
 int nrm_hash_add(nrm_hash_t **hash_table, nrm_string_t uuid, void *ptr)
 {
 	nrm_hash_t *local = NULL;
-	HASH_FIND(hh, (*hash_table), uuid, strlen(uuid), local);
+	HASH_FIND(hh, (*hash_table), uuid, nrm_string_strlen(uuid), local);
 	if (local != NULL)
 		return -NRM_FAILURE;
 
@@ -41,7 +41,7 @@ int nrm_hash_add(nrm_hash_t **hash_table, nrm_string_t uuid, void *ptr)
 		return -NRM_ENOMEM;
 	local->uuid = uuid;
 	local->ptr = ptr;
-	HASH_ADD_KEYPTR(hh, (*hash_table), uuid, strlen(uuid), local);
+	HASH_ADD_KEYPTR(hh, (*hash_table), uuid, nrm_string_strlen(uuid), local);
 	return NRM_SUCCESS;
 }
 
@@ -51,7 +51,7 @@ int nrm_hash_remove(nrm_hash_t **hash_table, nrm_string_t uuid, void **ptr)
 		return -NRM_EINVAL;
 
 	nrm_hash_t *tmp;
-	HASH_FIND(hh, (*hash_table), &uuid, strlen(uuid), tmp);
+	HASH_FIND(hh, (*hash_table), &uuid, nrm_string_strlen(uuid), tmp);
 
 	*ptr = tmp;
 	if (tmp != NULL) {
@@ -81,7 +81,7 @@ int nrm_hash_find(nrm_hash_t *hash_table, nrm_string_t uuid, void **ptr)
 		return -NRM_EINVAL;
 
 	nrm_hash_t *tmp = NULL;
-	HASH_FIND(hh, hash_table, uuid, strlen(uuid), tmp);
+	HASH_FIND(hh, hash_table, uuid, nrm_string_strlen(uuid), tmp);
 	if (tmp == NULL)
 		return -NRM_EINVAL;
 

--- a/src/utils/strings.c
+++ b/src/utils/strings.c
@@ -87,3 +87,12 @@ int nrm_string_cmp(nrm_string_t one, nrm_string_t two)
 	nrm_realstring_t *r1 = NRM_STRING_C2S(one);
 	return strncmp(one, two, r1->slen);
 }
+
+size_t nrm_string_strlen(const nrm_string_t s)
+{
+	if(s == NULL)
+		return 0;
+
+	nrm_realstring_t *r = NRM_STRING_C2S(s);
+	return r->slen;
+}


### PR DESCRIPTION
Since the string type stores the string length, no need for costly strlen calls.