### PR TITLE
[feature] proper nrm_msg_destroy API

### DIFF
--- a/include/internal/messages.h
+++ b/include/internal/messages.h
@@ -75,7 +75,8 @@ typedef Nrm__SliceList nrm_msg_slicelist_t;
 #define nrm_msg_slicelist_init(msg) nrm__slice_list__init(msg)
 
 nrm_msg_t *nrm_msg_create(void);
-void nrm_msg_destroy(nrm_msg_t **msg);
+void nrm_msg_destroy_created(nrm_msg_t **msg);
+void nrm_msg_destroy_received(nrm_msg_t **msg);
 void nrm_log_printmsg(int level, nrm_msg_t *msg);
 
 int nrm_msg_fill(nrm_msg_t *msg, int type);

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -423,8 +423,8 @@ int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
 	nrm_log_debug("crafting message\n");
 	nrm_msg_t *msg = nrm_msg_create();
 	nrm_msg_fill(msg, NRM_MSG_TYPE_EVENT);
-	nrm_msg_set_event(msg, now, my_daemon.mysensor->uuid,
-			  my_daemon.myscope, 1.0);
+	nrm_msg_set_event(msg, now, my_daemon.mysensor->uuid, my_daemon.myscope,
+	                  1.0);
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 	nrm_log_debug("sending event\n");
 	nrm_role_pub(self, my_daemon.mytopic, msg);
@@ -560,8 +560,8 @@ int main(int argc, char *argv[])
 	nrm_scope_hwloc_scopes(&my_daemon.state->scopes);
 	my_daemon.mysensor = nrm_sensor_create("daemon.tick");
 	nrm_string_t global_scope = nrm_string_fromchar("nrm.hwloc.Machine.0");
-	nrm_hash_find(my_daemon.state->scopes, global_scope, (void
-							      *)&my_daemon.myscope);
+	nrm_hash_find(my_daemon.state->scopes, global_scope,
+	              (void *)&my_daemon.myscope);
 	assert(my_daemon.myscope);
 	nrm_string_decref(global_scope);
 	my_daemon.mytopic = nrm_string_fromchar("daemon");

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -24,6 +24,9 @@ struct nrm_daemon_s {
 	nrm_state_t *state;
 	nrm_eventbase_t *events;
 	nrm_control_t *control;
+	nrm_sensor_t *mysensor;
+	nrm_scope_t *myscope;
+	nrm_string_t mytopic;
 };
 
 int signo;
@@ -88,6 +91,7 @@ nrm_msg_t *nrmd_daemon_build_list_actuators()
 	}
 
 	nrm_msg_set_list_actuators(ret, actuators_vector);
+	nrm_vector_destroy(&actuators_vector);
 	return ret;
 }
 
@@ -106,6 +110,7 @@ nrm_msg_t *nrmd_daemon_build_list_scopes()
 	}
 
 	nrm_msg_set_list_scopes(ret, scopes_vector);
+	nrm_vector_destroy(&scopes_vector);
 	return ret;
 }
 
@@ -124,6 +129,7 @@ nrm_msg_t *nrmd_daemon_build_list_sensors()
 	}
 
 	nrm_msg_set_list_sensors(ret, sensors_vector);
+	nrm_vector_destroy(&sensors_vector);
 	return ret;
 }
 
@@ -142,6 +148,7 @@ nrm_msg_t *nrmd_daemon_build_list_slices()
 	}
 
 	nrm_msg_set_list_slices(ret, slices_vector);
+	nrm_vector_destroy(&slices_vector);
 	return ret;
 }
 
@@ -372,7 +379,7 @@ int nrmd_shim_controller_read_callback(zloop_t *loop,
 		nrm_log_error("message type not handled\n");
 		break;
 	}
-	nrm_msg_destroy(&msg);
+	nrm_msg_destroy_received(&msg);
 	return err;
 }
 
@@ -409,22 +416,18 @@ int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
 	nrm_log_info("global timer wakeup\n");
 	nrm_role_t *self = (nrm_role_t *)arg;
 
-	nrm_string_t topic = nrm_string_fromchar("DAEMON");
-
 	/* create a ticking event */
 	nrm_time_t now;
 	nrm_time_gettime(&now);
-	nrm_scope_t *scope = nrm_scope_create("nrm.scope.all");
-	nrm_scope_threadprivate(scope);
-	nrm_sensor_t *sensor = nrm_sensor_create("daemon.tick");
 
 	nrm_log_debug("crafting message\n");
 	nrm_msg_t *msg = nrm_msg_create();
 	nrm_msg_fill(msg, NRM_MSG_TYPE_EVENT);
-	nrm_msg_set_event(msg, now, sensor->uuid, scope, 1.0);
+	nrm_msg_set_event(msg, now, my_daemon.mysensor->uuid,
+			  my_daemon.myscope, 1.0);
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 	nrm_log_debug("sending event\n");
-	nrm_role_pub(self, topic, msg);
+	nrm_role_pub(self, my_daemon.mytopic, msg);
 
 	/* tick the event base */
 	nrm_log_debug("eventbase tick\n");
@@ -468,6 +471,8 @@ int nrmd_timer_callback(zloop_t *loop, int timerid, void *arg)
 static int
 nrmd_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
 {
+	(void)loop;
+	(void)arg;
 	struct signalfd_siginfo fdsi;
 	ssize_t s = read(poller->fd, &fdsi, sizeof(struct signalfd_siginfo));
 	assert(s == sizeof(struct signalfd_siginfo));
@@ -553,6 +558,13 @@ int main(int argc, char *argv[])
 	my_daemon.state = nrm_state_create();
 	my_daemon.events = nrm_eventbase_create(5);
 	nrm_scope_hwloc_scopes(&my_daemon.state->scopes);
+	my_daemon.mysensor = nrm_sensor_create("daemon.tick");
+	nrm_string_t global_scope = nrm_string_fromchar("nrm.hwloc.Machine.0");
+	nrm_hash_find(my_daemon.state->scopes, global_scope, (void
+							      *)&my_daemon.myscope);
+	assert(my_daemon.myscope);
+	nrm_string_decref(global_scope);
+	my_daemon.mytopic = nrm_string_fromchar("daemon");
 
 	/* configuration */
 	if (argc == 0) {
@@ -614,6 +626,8 @@ start:
 	nrm_log_debug("Loop destroyed\n");
 
 	/* teardown NRM */
+	nrm_string_decref(my_daemon.mytopic);
+	nrm_sensor_destroy(&my_daemon.mysensor);
 	nrm_eventbase_destroy(&my_daemon.events);
 	nrm_state_destroy(&my_daemon.state);
 	nrm_role_destroy(&controller);

--- a/src/client.c
+++ b/src/client.c
@@ -91,6 +91,7 @@ int nrm_client_actuate(const nrm_client_t *client,
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
 	assert(msg->type == NRM_MSG_TYPE_ACK);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -122,6 +123,7 @@ int nrm_client_add_actuator(const nrm_client_t *client,
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_ACTUATOR);
 	nrm_actuator_update_frommsg(actuator, msg->add->actuator);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -152,6 +154,7 @@ int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope)
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SCOPE);
 	nrm_scope_update_frommsg(scope, msg->add->scope);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -182,6 +185,7 @@ int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice)
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SLICE);
 	nrm_slice_update_frommsg(slice, msg->add->slice);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -212,6 +216,7 @@ int nrm_client_add_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
 	assert(msg->type == NRM_MSG_TYPE_ADD);
 	assert(msg->add->type == NRM_MSG_TARGET_TYPE_SENSOR);
 	nrm_sensor_update_frommsg(sensor, msg->add->sensor);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -320,6 +325,7 @@ int nrm_client_find(const nrm_client_t *client,
 		}
 	}
 	*results = ret;
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -422,6 +428,7 @@ int nrm_client_list_actuators(const nrm_client_t *client,
 		nrm_vector_push_back(ret, &s);
 	}
 	*actuators = ret;
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -463,6 +470,7 @@ int nrm_client_list_scopes(const nrm_client_t *client, nrm_vector_t **scopes)
 		nrm_vector_push_back(ret, &s);
 	}
 	*scopes = ret;
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -504,6 +512,7 @@ int nrm_client_list_sensors(const nrm_client_t *client, nrm_vector_t **sensors)
 		nrm_vector_push_back(ret, &s);
 	}
 	*sensors = ret;
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -545,6 +554,7 @@ int nrm_client_list_slices(const nrm_client_t *client, nrm_vector_t **slices)
 		nrm_vector_push_back(ret, &s);
 	}
 	*slices = ret;
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -574,6 +584,7 @@ int nrm_client_remove_actuator(const nrm_client_t *client,
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
 	assert(msg->type == NRM_MSG_TYPE_ACK);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -602,6 +613,7 @@ int nrm_client_remove_scope(const nrm_client_t *client, nrm_scope_t *scope)
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
 	assert(msg->type == NRM_MSG_TYPE_ACK);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -630,6 +642,7 @@ int nrm_client_remove_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
 	assert(msg->type == NRM_MSG_TYPE_ACK);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -658,6 +671,7 @@ int nrm_client_remove_slice(const nrm_client_t *client, nrm_slice_t *slice)
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 
 	assert(msg->type == NRM_MSG_TYPE_ACK);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -275,7 +275,7 @@ void nrm_msg_add_destroy(nrm_msg_add_t *msg)
 	if (msg == NULL)
 		return;
 
-	switch(msg->type) {
+	switch (msg->type) {
 	case NRM_MSG_TARGET_TYPE_SLICE:
 		nrm_msg_slice_destroy(msg->slice);
 		break;
@@ -491,7 +491,7 @@ void nrm_msg_list_destroy(nrm_msg_list_t *msg)
 	if (msg == NULL)
 		return;
 
-	switch(msg->type) {
+	switch (msg->type) {
 	case NRM_MSG_TARGET_TYPE_SLICE:
 		nrm_msg_slicelist_destroy(msg->slices);
 		break;

--- a/src/messages.c
+++ b/src/messages.c
@@ -31,7 +31,7 @@ nrm_msg_t *nrm_msg_create(void)
 	return ret;
 }
 
-void nrm_msg_destroy(nrm_msg_t **msg)
+void nrm_msg_destroy_received(nrm_msg_t **msg)
 {
 	if (msg == NULL || *msg == NULL)
 		return;
@@ -58,6 +58,15 @@ nrm_msg_actuate_t *nrm_msg_actuate_new(nrm_string_t uuid, double value)
 	return ret;
 }
 
+void nrm_msg_actuate_destroy(nrm_msg_actuate_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg);
+}
+
 nrm_msg_sensor_t *nrm_msg_sensor_new(const char *uuid)
 {
 	nrm_msg_sensor_t *ret = calloc(1, sizeof(nrm_msg_sensor_t));
@@ -68,6 +77,15 @@ nrm_msg_sensor_t *nrm_msg_sensor_new(const char *uuid)
 	return ret;
 }
 
+void nrm_msg_sensor_destroy(nrm_msg_sensor_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg);
+}
+
 nrm_msg_slice_t *nrm_msg_slice_new(const char *uuid)
 {
 	nrm_msg_slice_t *ret = calloc(1, sizeof(nrm_msg_slice_t));
@@ -76,6 +94,15 @@ nrm_msg_slice_t *nrm_msg_slice_new(const char *uuid)
 	nrm_msg_slice_init(ret);
 	ret->uuid = strdup(uuid);
 	return ret;
+}
+
+void nrm_msg_slice_destroy(nrm_msg_slice_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg);
 }
 
 nrm_msg_add_t *nrm_msg_add_new(int type)
@@ -109,6 +136,17 @@ nrm_msg_actuator_t *nrm_msg_actuator_new(nrm_actuator_t *actuator)
 	return ret;
 }
 
+void nrm_msg_actuator_destroy(nrm_msg_actuator_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg->clientid);
+	free(msg->choices);
+	free(msg);
+}
+
 nrm_msg_scope_t *nrm_msg_scope_new(nrm_scope_t *scope)
 {
 	nrm_msg_scope_t *ret = calloc(1, sizeof(nrm_msg_scope_t));
@@ -125,6 +163,18 @@ nrm_msg_scope_t *nrm_msg_scope_new(nrm_scope_t *scope)
 	return ret;
 }
 
+void nrm_msg_scope_destroy(nrm_msg_scope_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg->cpus);
+	free(msg->numas);
+	free(msg->gpus);
+	free(msg);
+}
+
 nrm_msg_event_t *nrm_msg_event_new(nrm_string_t uuid)
 {
 	nrm_msg_event_t *ret = calloc(1, sizeof(nrm_msg_event_t));
@@ -133,6 +183,16 @@ nrm_msg_event_t *nrm_msg_event_new(nrm_string_t uuid)
 	nrm_msg_event_init(ret);
 	ret->uuid = strdup(uuid);
 	return ret;
+}
+
+void nrm_msg_event_destroy(nrm_msg_event_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	nrm_msg_scope_destroy(msg->scope);
+	free(msg->uuid);
+	free(msg);
 }
 
 int nrm_msg_set_event(nrm_msg_t *msg,
@@ -210,6 +270,30 @@ int nrm_msg_set_add_slice(nrm_msg_t *msg, nrm_slice_t *slice)
 	return 0;
 }
 
+void nrm_msg_add_destroy(nrm_msg_add_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	switch(msg->type) {
+	case NRM_MSG_TARGET_TYPE_SLICE:
+		nrm_msg_slice_destroy(msg->slice);
+		break;
+	case NRM_MSG_TARGET_TYPE_SENSOR:
+		nrm_msg_sensor_destroy(msg->sensor);
+		break;
+	case NRM_MSG_TARGET_TYPE_SCOPE:
+		nrm_msg_scope_destroy(msg->scope);
+		break;
+	case NRM_MSG_TARGET_TYPE_ACTUATOR:
+		nrm_msg_actuator_destroy(msg->actuator);
+		break;
+	default:
+		break;
+	}
+	free(msg);
+}
+
 static nrm_msg_list_t *nrm_msg_list_new(int type)
 {
 	nrm_msg_list_t *ret = calloc(1, sizeof(nrm_msg_list_t));
@@ -242,6 +326,17 @@ nrm_msg_actuatorlist_t *nrm_msg_actuatorlist_new(nrm_vector_t *actuators)
 	return ret;
 }
 
+void nrm_msg_actuatorlist_destroy(nrm_msg_actuatorlist_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	for (size_t i = 0; i < msg->n_actuators; i++)
+		nrm_msg_actuator_destroy(msg->actuators[i]);
+	free(msg->actuators);
+	free(msg);
+}
+
 nrm_msg_scopelist_t *nrm_msg_scopelist_new(nrm_vector_t *scopes)
 {
 	nrm_msg_scopelist_t *ret = calloc(1, sizeof(nrm_msg_scopelist_t));
@@ -262,6 +357,17 @@ nrm_msg_scopelist_t *nrm_msg_scopelist_new(nrm_vector_t *scopes)
 		ret->scopes[i] = nrm_msg_scope_new(s);
 	}
 	return ret;
+}
+
+void nrm_msg_scopelist_destroy(nrm_msg_scopelist_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	for (size_t i = 0; i < msg->n_scopes; i++)
+		nrm_msg_scope_destroy(msg->scopes[i]);
+	free(msg->scopes);
+	free(msg);
 }
 
 nrm_msg_sensorlist_t *nrm_msg_sensorlist_new(nrm_vector_t *sensors)
@@ -287,6 +393,17 @@ nrm_msg_sensorlist_t *nrm_msg_sensorlist_new(nrm_vector_t *sensors)
 	return ret;
 }
 
+void nrm_msg_sensorlist_destroy(nrm_msg_sensorlist_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	for (size_t i = 0; i < msg->n_sensors; i++)
+		nrm_msg_sensor_destroy(msg->sensors[i]);
+	free(msg->sensors);
+	free(msg);
+}
+
 nrm_msg_slicelist_t *nrm_msg_slicelist_new(nrm_vector_t *slices)
 {
 	nrm_msg_slicelist_t *ret = calloc(1, sizeof(nrm_msg_slicelist_t));
@@ -308,6 +425,17 @@ nrm_msg_slicelist_t *nrm_msg_slicelist_new(nrm_vector_t *slices)
 		ret->slices[i] = nrm_msg_slice_new(s->uuid);
 	}
 	return ret;
+}
+
+void nrm_msg_slicelist_destroy(nrm_msg_slicelist_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	for (size_t i = 0; i < msg->n_slices; i++)
+		nrm_msg_slice_destroy(msg->slices[i]);
+	free(msg->slices);
+	free(msg);
 }
 
 int nrm_msg_set_list_actuators(nrm_msg_t *msg, nrm_vector_t *actuators)
@@ -358,6 +486,30 @@ int nrm_msg_set_list_slices(nrm_msg_t *msg, nrm_vector_t *slices)
 	return 0;
 }
 
+void nrm_msg_list_destroy(nrm_msg_list_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	switch(msg->type) {
+	case NRM_MSG_TARGET_TYPE_SLICE:
+		nrm_msg_slicelist_destroy(msg->slices);
+		break;
+	case NRM_MSG_TARGET_TYPE_SENSOR:
+		nrm_msg_sensorlist_destroy(msg->sensors);
+		break;
+	case NRM_MSG_TARGET_TYPE_SCOPE:
+		nrm_msg_scopelist_destroy(msg->scopes);
+		break;
+	case NRM_MSG_TARGET_TYPE_ACTUATOR:
+		nrm_msg_actuatorlist_destroy(msg->actuators);
+		break;
+	default:
+		break;
+	}
+	free(msg);
+}
+
 nrm_msg_remove_t *nrm_msg_remove_new(int type, nrm_string_t uuid)
 {
 	nrm_msg_remove_t *ret = calloc(1, sizeof(nrm_msg_remove_t));
@@ -369,6 +521,15 @@ nrm_msg_remove_t *nrm_msg_remove_new(int type, nrm_string_t uuid)
 	return ret;
 }
 
+void nrm_msg_remove_destroy(nrm_msg_remove_t *msg)
+{
+	if (msg == NULL)
+		return;
+
+	free(msg->uuid);
+	free(msg);
+}
+
 int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_string_t uuid)
 {
 	if (msg == NULL)
@@ -377,6 +538,36 @@ int nrm_msg_set_remove(nrm_msg_t *msg, int type, nrm_string_t uuid)
 	assert(msg->remove);
 	msg->data_case = NRM__MESSAGE__DATA_REMOVE;
 	return 0;
+}
+
+void nrm_msg_destroy_created(nrm_msg_t **msg)
+{
+	if (msg == NULL || *msg == NULL)
+		return;
+
+	nrm_msg_t *sub = *msg;
+	switch (sub->type) {
+	case NRM_MSG_TYPE_ACTUATE:
+		nrm_msg_actuate_destroy(sub->actuate);
+		break;
+	case NRM_MSG_TYPE_ADD:
+		nrm_msg_add_destroy(sub->add);
+		break;
+	case NRM_MSG_TYPE_LIST:
+		nrm_msg_list_destroy(sub->list);
+		break;
+	case NRM_MSG_TYPE_EVENT:
+		nrm_msg_event_destroy(sub->event);
+		break;
+	case NRM_MSG_TYPE_REMOVE:
+		nrm_msg_remove_destroy(sub->remove);
+		break;
+	case NRM_MSG_TYPE_ACK:
+	default:
+		break;
+	}
+	free(*msg);
+	*msg = NULL;
 }
 
 /*******************************************************************************
@@ -937,6 +1128,7 @@ int nrm_ctrlmsg__recv(zsock_t *socket, int *type, void **p1, void **p2)
 	if (p2 != NULL) {
 		*p2 = q;
 	}
+	free(s);
 	return err;
 }
 

--- a/src/messages.c
+++ b/src/messages.c
@@ -563,6 +563,7 @@ void nrm_msg_destroy_created(nrm_msg_t **msg)
 		nrm_msg_remove_destroy(sub->remove);
 		break;
 	case NRM_MSG_TYPE_ACK:
+	case NRM_MSG_TYPE_EXIT:
 	default:
 		break;
 	}

--- a/src/roles/client.c
+++ b/src/roles/client.c
@@ -86,6 +86,7 @@ int nrm_client_broker_pipe_handler(zloop_t *loop, zsock_t *socket, void *arg)
 		nrm_log_debug("client sending message\n");
 		nrm_log_printmsg(NRM_LOG_DEBUG, msg);
 		nrm_msg_send(self->rpc, msg);
+		nrm_msg_destroy_created(&msg);
 		break;
 	case NRM_CTRLMSG_TYPE_SUB:
 		NRM_CTRLMSG_2SUB(p, q, s);
@@ -96,8 +97,6 @@ int nrm_client_broker_pipe_handler(zloop_t *loop, zsock_t *socket, void *arg)
 		/* returning -1 exits the loop */
 		return -1;
 	}
-	/* we've taken ownership of the message at this point */
-	nrm_msg_destroy(&msg);
 	return 0;
 }
 
@@ -118,6 +117,7 @@ int nrm_client_broker_rpc_handler(zloop_t *loop, zsock_t *socket, void *arg)
 			self->cmd_cb->fn(msg, self->cmd_cb->arg);
 		else
 			nrm_log_debug("no cmd callback to call\n");
+		nrm_msg_destroy_received(&msg);
 	}
 	return 0;
 }
@@ -133,11 +133,11 @@ int nrm_client_broker_sub_handler(zloop_t *loop, zsock_t *socket, void *arg)
 	nrm_msg_t *msg = nrm_msg_sub(socket, &topic);
 	nrm_log_debug("received subscribed message\n");
 	nrm_log_printmsg(NRM_LOG_DEBUG, msg);
-	if (self->sub_cb == NULL || self->sub_cb->fn == NULL) {
+	if (self->sub_cb == NULL || self->sub_cb->fn == NULL)
 		nrm_log_debug("no callback to call\n");
-		return 0;
-	}
-	self->sub_cb->fn(msg, self->sub_cb->arg);
+	else
+		self->sub_cb->fn(msg, self->sub_cb->arg);
+	nrm_msg_destroy_received(&msg);
 	return 0;
 }
 
@@ -319,6 +319,7 @@ int nrm_role_client_sub(const struct nrm_role_data *data, nrm_string_t topic)
 {
 	struct nrm_role_client_s *client = (struct nrm_role_client_s *)data;
 	nrm_ctrlmsg_sub((zsock_t *)client->broker, NRM_CTRLMSG_TYPE_SUB, topic);
+	return 0;
 }
 
 struct nrm_role_ops nrm_role_client_ops = {

--- a/src/roles/controller.c
+++ b/src/roles/controller.c
@@ -78,11 +78,15 @@ int nrm_controller_broker_pipe_handler(zloop_t *loop,
 		NRM_CTRLMSG_2SENDTO(p, q, msg, uuid);
 		nrm_log_info("received request to send to client: %s\n", *uuid);
 		nrm_msg_sendto(self->rpc, msg, uuid);
+		nrm_msg_destroy_created(&msg);
+		nrm_uuid_destroy(&uuid);
 		break;
 	case NRM_CTRLMSG_TYPE_PUB:
 		nrm_log_info("received request to publish message\n");
 		NRM_CTRLMSG_2PUB(p, q, s, msg);
 		nrm_msg_pub(self->pub, s, msg);
+		nrm_string_decref(s);
+		nrm_msg_destroy_created(&msg);
 		break;
 	default:
 		nrm_log_error("msg type %u not handled\n", msg_type);
@@ -231,6 +235,7 @@ int nrm_role_controller_pub(const struct nrm_role_data *data,
 {
 	struct nrm_role_controller_s *controller =
 	        (struct nrm_role_controller_s *)data;
+	nrm_string_incref(topic);
 	nrm_ctrlmsg_pub((zsock_t *)controller->broker, NRM_CTRLMSG_TYPE_PUB,
 	                topic, msg);
 	return 0;


### PR DESCRIPTION
Create two nrm_msg_destroy functions, depending on whether we received the msg from unpacking a protobuf-encoded zmq message, or created the msg ourselves.

Call the new API everywhere as needed.

Tested with a bunch of valgrind leak checks on live processes, both nrmd and nrmc.