### PR TITLE
[fix] Add missing newlines to log outputs

### DIFF
--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -37,9 +37,15 @@ static struct option long_options[] = {
 
 static const char *short_options = "+hVu:r:p:";
 
-static const char *help[] = {"Usage: nrmc [options]\n\n", "Allowed options:\n",
-                             "--help, -h    : print this help message\n",
-                             "--version, -V : print program version\n", NULL};
+static const char *help[] = {
+        "Usage: nrmc [options]\n\n",
+        "Allowed options:\n",
+        "--help, -h    : print this help message\n",
+        "--version, -V : print program version\n",
+        "--uri, -u     : daemon socket uri to connect to\n",
+        "--rpc-port    : daemon rpc port to use\n",
+        "--pub-port    : daemon pub/sub port to use\n",
+        NULL};
 
 void print_help()
 {

--- a/src/binaries/nrmd.c
+++ b/src/binaries/nrmd.c
@@ -568,7 +568,7 @@ int main(int argc, char *argv[])
 
 	/* configuration */
 	if (argc == 0) {
-		nrm_log_info("no configuration given, skipping control config");
+		nrm_log_info("no configuration given, skipping control\n");
 		goto start;
 	}
 

--- a/src/client.c
+++ b/src/client.c
@@ -55,7 +55,7 @@ int nrm_client_actuate(const nrm_client_t *client,
 	if (client == NULL || actuator == NULL)
 		return -NRM_EINVAL;
 
-	nrm_log_debug("checking value is valid");
+	nrm_log_debug("checking value is valid\n");
 	size_t i, len;
 	nrm_vector_length(actuator->choices, &len);
 	for (i = 0; i < len; i++) {


### PR DESCRIPTION
During the last round of experiments, I noticed that newlines were missing in a few places.

Also update nrmc help to include uri/port options.