### PR TITLE
Add a named scope type

### DIFF
--- a/include/nrm.h
+++ b/include/nrm.h
@@ -148,7 +148,7 @@ void nrm_actuator_fprintf(FILE *out, nrm_actuator_t *);
  ******************************************************************************/
 
 int nrm_scope_hwloc_scopes(nrm_hash_t **scopes);
-nrm_scope_t *nrm_scope_create_hwloc_allowed(const char *name);
+nrm_scope_t *nrm_scope_create_hwloc_allowed();
 
 /*******************************************************************************
  * Slice: a resource arbitration unit

--- a/include/nrm/utils/scopes.h
+++ b/include/nrm/utils/scopes.h
@@ -22,15 +22,26 @@
  **/
 typedef struct nrm_scope nrm_scope_t;
 
-/**
- * Creates and returns a new NRM scope
- */
-nrm_scope_t *nrm_scope_create(const char *name);
-
 #define NRM_SCOPE_TYPE_CPU 0
 #define NRM_SCOPE_TYPE_NUMA 1
 #define NRM_SCOPE_TYPE_GPU 2
 #define NRM_SCOPE_TYPE_MAX 3
+
+/**
+ * a named scope, as maintained by the daemon.
+ */
+typedef struct nrm_named_scope_s {
+	nrm_string_t name;
+	nrm_scope_t *scope;
+} nrm_named_scope_t;
+
+nrm_named_scope_t *nrm_named_scope_create(const char *name, nrm_scope_t *scope);
+int nrm_named_scope_destroy(nrm_named_scope_t **);
+
+/**
+ * Creates and returns a new NRM scope
+ */
+nrm_scope_t *nrm_scope_create();
 
 /**
  * Add an int corresponding to some hardware ID to the list

--- a/tests/utils/scope.c
+++ b/tests/utils/scope.c
@@ -16,11 +16,24 @@
 #include "internal/messages.h"
 #include "internal/nrmi.h"
 
+START_TEST(named_from_json)
+{
+
+	json_t *valid_named_scope = json_loads("{\"uuid\": \"test\", \"cpu\": [0]}", 0, NULL);
+	nrm_named_scope_t *scope = nrm_named_scope_create_fromjson(valid_named_scope);
+	ck_assert_ptr_nonnull(scope);
+	ck_assert_int_eq(nrm_bitmap_isset(&(scope->scope->maps[NRM_SCOPE_TYPE_CPU]), 0), 0);
+	nrm_named_scope_destroy(&scope);
+	json_decref(valid_cpu_scope);
+}
+END_TEST
+
+
 START_TEST(test_from_json)
 {
 
 	json_t *valid_cpu_scope = json_loads("{\"cpu\": [0]}", 0, NULL);
-	nrm_scope_t *scope = nrm_scope_create("test");
+	nrm_scope_t *scope = nrm_scope_create();
 	nrm_scope_from_json(scope, valid_cpu_scope);
 	assert(nrm_bitmap_isset(&scope->maps[NRM_SCOPE_TYPE_CPU], 0));
 	nrm_scope_destroy(scope);
@@ -36,6 +49,7 @@ Suite *scope_suite(void)
 
 	TCase *tc_json = tcase_create("json");
 	tcase_add_test(tc_json, test_from_json);
+	tcase_add_test(tc_json, test_named_from_json);
 	suite_add_tcase(s, tc_json);
 
 	return s;


### PR DESCRIPTION
Related to #66 

Need to change the full API to make scopes unnamed, and have clients differentiate between named scopes and info about topology.

This is a work in progress, but will be needed before a new release.