### PR TITLE
[feature] add timeout to send/recv/connect

### DIFF
--- a/include/internal/nrmi.h
+++ b/include/internal/nrmi.h
@@ -37,8 +37,7 @@ int nrm_net_rpc_server_init(zsock_t **socket);
 int nrm_net_sub_init(zsock_t **socket);
 int nrm_net_sub_set_topic(zsock_t *socket, const char *topic);
 int nrm_net_pub_init(zsock_t **socket);
-int nrm_net_connect_and_wait(zsock_t *socket, const char *uri);
-int nrm_net_connect_and_wait_2(zsock_t *socket, const char *uri, int port);
+int nrm_net_connect_and_wait(zsock_t *socket, const char *uri, int port);
 int nrm_net_bind(zsock_t *socket, const char *uri);
 int nrm_net_bind_2(zsock_t *socket, const char *uri, int port);
 

--- a/include/nrm/utils/variables.h
+++ b/include/nrm/utils/variables.h
@@ -41,6 +41,12 @@
  */
 #define NRM_ENV_VAR_TRANSMIT "NRM_TRANSMIT"
 
+/**
+ * name of the environment variable for default timeout value when
+ * sending/receving messages (in milliseconds)
+ */
+#define NRM_ENV_VAR_TIMEOUT "NRM_TIMEOUT"
+
 /*******************************************************************************
  * Common environment default values
  ******************************************************************************/
@@ -71,6 +77,11 @@
  */
 #define NRM_DEFAULT_TRANSMIT 1
 
+/**
+ * default timeout value (1000: one second)
+ */
+#define NRM_DEFAULT_TIMEOUT 1000
+
 /*******************************************************************************
  * Runtime variables storing these values:
  * - before nrm_init, contain default values
@@ -78,9 +89,10 @@
  ******************************************************************************/
 
 extern char *nrm_upstream_uri;
-extern int nrm_upstream_rpc_port;
-extern int nrm_upstream_pub_port;
+extern unsigned int nrm_upstream_rpc_port;
+extern unsigned int nrm_upstream_pub_port;
 extern unsigned long long nrm_ratelimit;
 extern int nrm_transmit;
+extern unsigned int nrm_timeout;
 
 #endif /* NRM_VARIABLES_H */

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -60,8 +60,12 @@ int main(int argc, char *argv[])
 	              argc, argv[0]);
 
 	nrm_log_info("creating client\n");
-	nrm_client_create(&client, args.upstream_uri, args.pub_port,
-	                  args.rpc_port);
+	err = nrm_client_create(&client, args.upstream_uri, args.pub_port,
+	                        args.rpc_port);
+	if (err) {
+		nrm_log_error("error during client creation: %d\n", err);
+		return EXIT_FAILURE;
+	}
 
 	nrm_sensor_t *sensor;
 	nrm_scope_t *scope;

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -762,8 +762,12 @@ int main(int argc, char *argv[])
 	              argc, argv[0]);
 
 	nrm_log_info("creating client\n");
-	nrm_client_create(&client, args.upstream_uri, args.pub_port,
-	                  args.rpc_port);
+	err = nrm_client_create(&client, args.upstream_uri, args.pub_port,
+	                        args.rpc_port);
+	if (err) {
+		nrm_log_error("error during client creation: %d\n", err);
+		goto cleanup;
+	}
 
 	for (int i = 0; commands[i].name != NULL; i++) {
 		if (!strcmp(argv[0], commands[i].name)) {
@@ -775,6 +779,7 @@ int main(int argc, char *argv[])
 	err = EXIT_FAILURE;
 end:
 	nrm_client_destroy(&client);
+cleanup:
 	nrm_finalize();
 	return err;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -34,6 +34,9 @@ int nrm_net_rpc_client_init(zsock_t **socket)
 	zsock_set_immediate(ret, 1);
 	/* buffer as many messages as possible */
 	zsock_set_unbounded(ret);
+	/* set timeout on send/recv */
+	zsock_set_sndtimeo(ret, nrm_timeout);
+	zsock_set_rcvtimeo(ret, nrm_timeout);
 	/* add an identity to the socket */
 	nrm_uuid_t *uuid = nrm_uuid_create();
 	zsock_set_identity(ret, nrm_uuid_to_char(uuid));
@@ -55,6 +58,9 @@ int nrm_net_rpc_server_init(zsock_t **socket)
 	zsock_set_immediate(ret, 1);
 	/* buffer as many messages as possible */
 	zsock_set_unbounded(ret);
+	/* set timeout on send/recv */
+	zsock_set_sndtimeo(ret, nrm_timeout);
+	zsock_set_rcvtimeo(ret, nrm_timeout);
 	*socket = ret;
 	return 0;
 }
@@ -95,54 +101,7 @@ int nrm_net_pub_init(zsock_t **socket)
 	return 0;
 }
 
-int nrm_net_connect_and_wait(zsock_t *socket, const char *uri)
-{
-	/* the process is a little more complicated that you would think, as
-	 * we're trying to avoid returning from this function before the socket
-	 * is fully connected.
-	 *
-	 * To do that, we also create a socket monitor (socket pair + actor)
-	 * that will loop until we actually receive a connection message.
-	 *
-	 * To avoid missing that message on the monitor, we're also careful of
-	 * connecting the monitor before connecting the real socket to the
-	 * server.
-	 */
-	int err;
-
-	if (!nrm_transmit)
-		return 0;
-
-	zactor_t *monitor = zactor_new(zmonitor, socket);
-	assert(monitor != NULL);
-
-	zstr_sendx(monitor, "LISTEN", "CONNECTED", NULL);
-	zstr_send(monitor, "START");
-	zsock_wait(monitor);
-
-	/* now connect the original client */
-	err = zsock_connect(socket, "%s", uri);
-	assert(err == 0);
-
-	int connected = 0;
-	while (!connected) {
-		/* read first frame for event number */
-		zmsg_t *msg = zmsg_recv(monitor);
-		assert(msg != NULL);
-
-		char *event = zmsg_popstr(msg);
-
-		if (!strcmp(event, "CONNECTED"))
-			connected = 1;
-		free(event);
-		zmsg_destroy(&msg);
-	}
-	/* cleanup monitor */
-	zactor_destroy(&monitor);
-	return 0;
-}
-
-int nrm_net_connect_and_wait_2(zsock_t *socket, const char *uri, int port)
+int nrm_net_connect_and_wait(zsock_t *socket, const char *uri, int port)
 {
 	/* the process is a little more complicated that you would think, as
 	 * we're trying to avoid returning from this function before the socket
@@ -169,17 +128,25 @@ int nrm_net_connect_and_wait_2(zsock_t *socket, const char *uri, int port)
 	zstr_send(monitor, "START");
 	nrm_log_debug("waiting socket monitor\n");
 	zsock_wait(monitor);
+	zsock_set_rcvtimeo(monitor, nrm_timeout);
 
 	/* now connect the original client */
 	nrm_log_debug("connecting to %s:%d\n", uri, port);
 	err = zsock_connect(socket, "%s:%d", uri, port);
-	assert(err == 0);
+	if (err) {
+		nrm_log_error("error connecting %d\n", err);
+		goto cleanup;
+	}
 
 	int connected = 0;
 	while (!connected) {
 		/* read first frame for event number */
 		zmsg_t *msg = zmsg_recv(monitor);
-		assert(msg != NULL);
+		if (msg == NULL) {
+			nrm_log_error("socket monitor timeout\n");
+			err = -NRM_FAILURE;
+			goto cleanup;
+		}
 
 		char *event = zmsg_popstr(msg);
 
@@ -190,9 +157,10 @@ int nrm_net_connect_and_wait_2(zsock_t *socket, const char *uri, int port)
 		zmsg_destroy(&msg);
 	}
 	nrm_log_debug("connection established\n");
+cleanup:
 	/* cleanup monitor */
 	zactor_destroy(&monitor);
-	return 0;
+	return err;
 }
 
 int nrm_net_bind(zsock_t *socket, const char *uri)

--- a/src/net.c
+++ b/src/net.c
@@ -103,7 +103,7 @@ int nrm_net_pub_init(zsock_t **socket)
 
 int nrm_net_connect_and_wait(zsock_t *socket, const char *uri, int port)
 {
-	/* the process is a little more complicated that you would think, as
+	/* the process is a little more complicated than you would think, as
 	 * we're trying to avoid returning from this function before the socket
 	 * is fully connected.
 	 *

--- a/src/nrm.c
+++ b/src/nrm.c
@@ -11,6 +11,7 @@
 #include "config.h"
 
 #include "nrm.h"
+#include <stdlib.h>
 
 const int nrm_version_major = NRM_VERSION_MAJOR;
 const int nrm_version_minor = NRM_VERSION_MINOR;
@@ -18,10 +19,11 @@ const int nrm_version_patch = NRM_VERSION_PATCH;
 const char *nrm_version_revision = NRM_VERSION_REVISION;
 const char *nrm_version_string = NRM_VERSION_STRING;
 
-extern char *nrm_upstream_uri = NRM_DEFAULT_UPSTREAM_URI;
-extern int nrm_upstream_rpc_port = NRM_DEFAULT_UPSTREAM_RPC_PORT;
-extern int nrm_upstream_pub_port = NRM_DEFAULT_UPSTREAM_PUB_PORT;
+char *nrm_upstream_uri = NRM_DEFAULT_UPSTREAM_URI;
+unsigned int nrm_upstream_rpc_port = NRM_DEFAULT_UPSTREAM_RPC_PORT;
+unsigned int nrm_upstream_pub_port = NRM_DEFAULT_UPSTREAM_PUB_PORT;
 unsigned long long nrm_ratelimit = NRM_DEFAULT_RATELIMIT;
+unsigned int nrm_timeout = NRM_DEFAULT_TIMEOUT;
 int nrm_transmit = NRM_DEFAULT_TRANSMIT;
 int nrm_errno = 0;
 
@@ -29,11 +31,12 @@ int nrm_init(int *argc, char **argv[])
 {
 	(void)argc;
 	(void)argv;
-	const char *upstream_uri = getenv(NRM_ENV_VAR_UPSTREAM_URI);
-	const char *upstream_rpc = getenv(NRM_ENV_VAR_UPSTREAM_RPC_PORT);
-	const char *upstream_pub = getenv(NRM_ENV_VAR_UPSTREAM_PUB_PORT);
-	const char *rate = getenv(NRM_ENV_VAR_RATELIMIT);
-	const char *transmit = getenv(NRM_ENV_VAR_TRANSMIT);
+	char *upstream_uri = getenv(NRM_ENV_VAR_UPSTREAM_URI);
+	char *upstream_rpc = getenv(NRM_ENV_VAR_UPSTREAM_RPC_PORT);
+	char *upstream_pub = getenv(NRM_ENV_VAR_UPSTREAM_PUB_PORT);
+	char *rate = getenv(NRM_ENV_VAR_RATELIMIT);
+	char *transmit = getenv(NRM_ENV_VAR_TRANSMIT);
+	char *timeout = getenv(NRM_ENV_VAR_TIMEOUT);
 	int err;
 
 	/* setup a default log config to handle errors in this part of the
@@ -76,6 +79,15 @@ int nrm_init(int *argc, char **argv[])
 		if (err) {
 			nrm_log_error("can't parse %s variable\n",
 			              NRM_ENV_VAR_TRANSMIT);
+			return err;
+		}
+	}
+
+	if (timeout != NULL) {
+		err = nrm_parse_uint(timeout, &nrm_timeout);
+		if (err) {
+			nrm_log_error("can't parse %s variable\n",
+			              NRM_ENV_VAR_TIMEOUT);
 			return err;
 		}
 	}

--- a/tests/net.c
+++ b/tests/net.c
@@ -31,8 +31,8 @@ void setup_pubsub(void)
 	ck_assert_int_eq(nrm_net_sub_init(&client), 0);
 	ck_assert_ptr_nonnull(client);
 	ck_assert_int_eq(
-	        nrm_net_connect_and_wait_2(client, NRM_DEFAULT_UPSTREAM_URI,
-	                                   NRM_DEFAULT_UPSTREAM_PUB_PORT),
+	        nrm_net_connect_and_wait(client, NRM_DEFAULT_UPSTREAM_URI,
+	                                 NRM_DEFAULT_UPSTREAM_PUB_PORT),
 	        0);
 	/* subscription is as annoying as usual, can't guarantee that the
 	 * messages are showing up without waiting a bit
@@ -58,8 +58,8 @@ void setup_rpc(void)
 	ck_assert_int_eq(nrm_net_rpc_client_init(&client), 0);
 	ck_assert_ptr_nonnull(client);
 	ck_assert_int_eq(
-	        nrm_net_connect_and_wait_2(client, NRM_DEFAULT_UPSTREAM_URI,
-	                                   NRM_DEFAULT_UPSTREAM_RPC_PORT),
+	        nrm_net_connect_and_wait(client, NRM_DEFAULT_UPSTREAM_URI,
+	                                 NRM_DEFAULT_UPSTREAM_RPC_PORT),
 	        0);
 }
 


### PR DESCRIPTION
Add a timeout to send/recv and handle the errors on the client side. Should solve most of our issues with tests getting stuck forever too.