### PR TITLE
[feature] reactor object

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ libnrm_la_SOURCES = \
 		    src/control/control.c \
 		    src/control/europar21.c \
 		    src/hwloc.c \
+		    src/reactor.c \
 		    src/roles/client.c \
 		    src/roles/controller.c \
 		    src/roles/role.c \

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -502,6 +502,48 @@ int nrm_server_actuate(nrm_server_t *server, nrm_string_t uuid, double value);
  */
 void nrm_server_destroy(nrm_server_t **server);
 
+/*******************************************************************************
+ * NRM Reactor object
+ * Used by any program that wants to become an idle loop only waking up on
+ * signals or timers.
+ ******************************************************************************/
+
+typedef struct nrm_reactor_s nrm_reactor_t;
+
+/** User-level callbacks on reactor events */
+struct nrm_reactor_user_callbacks_s {
+	/* receiving a POSIX signal */
+	int (*signal)(nrm_reactor_t *, int);
+	/* timer trigger */
+	int (*timer)(nrm_reactor_t *);
+};
+
+typedef struct nrm_reactor_user_callbacks_s nrm_reactor_user_callbacks_t;
+
+/**
+ * Creates a new NRM reactor.
+ *
+ * Uses a state to keep track of reactor objects that clients can add/remove
+ * from the system.
+ *
+ * @param reactor: pointer to a valid state handle
+ * @return 0 if successful, an error code otherwise
+ *
+ */
+int nrm_reactor_create(nrm_reactor_t **reactor);
+
+int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
+                            nrm_reactor_user_callbacks_t callbacks);
+
+int nrm_reactor_settimer(nrm_reactor_t *reactor, nrm_time_t sleeptime);
+
+int nrm_reactor_start(nrm_reactor_t *reactor);
+
+/**
+ * Destroys an NRM reactor. Closes connections.
+ */
+void nrm_reactor_destroy(nrm_reactor_t **reactor);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/signalfd.h>
 #include <time.h>
 
 // clang-format off
@@ -513,7 +514,7 @@ typedef struct nrm_reactor_s nrm_reactor_t;
 /** User-level callbacks on reactor events */
 struct nrm_reactor_user_callbacks_s {
 	/* receiving a POSIX signal */
-	int (*signal)(nrm_reactor_t *, int);
+	int (*signal)(nrm_reactor_t *, struct signalfd_siginfo);
 	/* timer trigger */
 	int (*timer)(nrm_reactor_t *);
 };
@@ -530,7 +531,7 @@ typedef struct nrm_reactor_user_callbacks_s nrm_reactor_user_callbacks_t;
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_reactor_create(nrm_reactor_t **reactor);
+int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t mask);
 
 int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
                              nrm_reactor_user_callbacks_t callbacks);

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -531,7 +531,7 @@ typedef struct nrm_reactor_user_callbacks_s nrm_reactor_user_callbacks_t;
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t mask);
+int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t *mask);
 
 int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
                              nrm_reactor_user_callbacks_t callbacks);

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -533,7 +533,7 @@ typedef struct nrm_reactor_user_callbacks_s nrm_reactor_user_callbacks_t;
 int nrm_reactor_create(nrm_reactor_t **reactor);
 
 int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
-                            nrm_reactor_user_callbacks_t callbacks);
+                             nrm_reactor_user_callbacks_t callbacks);
 
 int nrm_reactor_settimer(nrm_reactor_t *reactor, nrm_time_t sleeptime);
 

--- a/nix/geopmd.nix
+++ b/nix/geopmd.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation {
   src = fetchTarball "https://github.com/geopm/geopm/releases/download/v2.0.2/geopm-service-2.0.2.tar.gz";
   name = "geopmd";
-  configureFlags = "--disable-mpi --disable-fortran";
+  configureFlags = [ "--disable-mpi" "--disable-fortran"];
   nativeBuildInputs = [ autoreconfHook pkgconfig git ];
   propagatedBuildInputs = [
     libelf 

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -117,11 +117,7 @@ int main(int argc, char *argv[])
 	nrm_client_start_actuate_listener(client);
 
 
-	sigset_t sigmask;
-	sigemptyset(&sigmask);
-	sigaddset(&sigmask, SIGINT);
-	sigaddset(&sigmask, SIGTERM);
-	err = nrm_reactor_create(&reactor, sigmask);
+	err = nrm_reactor_create(&reactor, NULL);
 	if (err) {
 		nrm_log_error("error during reactor creation\n");
 		return EXIT_FAILURE;

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -25,7 +25,6 @@ static nrm_sensor_t *sensor;
 static nrm_scope_t *scope;
 static nrm_actuator_t *actuator;
 
-
 int nrm_dummy_extra_action_callback(nrm_uuid_t *uuid, double value)
 {
 	(void)uuid;
@@ -113,7 +112,8 @@ int main(int argc, char *argv[])
 	}
 
 	nrm_log_info("starting dummy actuate callback\n");
-	nrm_client_set_actuate_listener(client, nrm_dummy_extra_action_callback);
+	nrm_client_set_actuate_listener(client,
+	                                nrm_dummy_extra_action_callback);
 	nrm_client_start_actuate_listener(client);
 
 	err = nrm_reactor_create(&reactor);
@@ -121,10 +121,10 @@ int main(int argc, char *argv[])
 		nrm_log_error("error during reactor creation\n");
 		return EXIT_FAILURE;
 	}
-	
+
 	nrm_reactor_user_callbacks_t callbacks = {
-		.signal = NULL,
-		.timer = nrm_dummy_extra_timer_callback,
+	        .signal = NULL,
+	        .timer = nrm_dummy_extra_timer_callback,
 	};
 	nrm_reactor_setcallbacks(reactor, callbacks);
 

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -116,7 +116,12 @@ int main(int argc, char *argv[])
 	                                nrm_dummy_extra_action_callback);
 	nrm_client_start_actuate_listener(client);
 
-	err = nrm_reactor_create(&reactor);
+
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGINT);
+	sigaddset(&sigmask, SIGTERM);
+	err = nrm_reactor_create(&reactor, sigmask);
 	if (err) {
 		nrm_log_error("error during reactor creation\n");
 		return EXIT_FAILURE;

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -116,7 +116,6 @@ int main(int argc, char *argv[])
 	                                nrm_dummy_extra_action_callback);
 	nrm_client_start_actuate_listener(client);
 
-
 	err = nrm_reactor_create(&reactor, NULL);
 	if (err) {
 		nrm_log_error("error during reactor creation\n");

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -14,6 +14,7 @@
 #include "nrm/tools.h"
 #include <errno.h>
 #include <math.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -34,6 +35,7 @@ int nrm_dummy_extra_action_callback(nrm_uuid_t *uuid, double value)
 
 int nrm_dummy_extra_timer_callback(nrm_reactor_t *reactor)
 {
+	(void)reactor;
 	nrm_time_t time;
 	nrm_time_gettime(&time);
 	nrm_client_send_event(client, time, sensor, scope, counter++);
@@ -132,8 +134,8 @@ int main(int argc, char *argv[])
 	/* idle loop */
 	nrm_reactor_start(reactor);
 
-	nrm_reactor_destroy(&reactor);
 	/* cleanup, only get there if signal or error */
+	nrm_reactor_destroy(&reactor);
 	nrm_client_destroy(&client);
 	nrm_finalize();
 	return 0;

--- a/src/binaries/nrm-dummy-extra.c
+++ b/src/binaries/nrm-dummy-extra.c
@@ -18,11 +18,25 @@
 #include <stdlib.h>
 
 static nrm_client_t *client;
+static nrm_reactor_t *reactor;
+static int counter = 0;
+static nrm_sensor_t *sensor;
+static nrm_scope_t *scope;
+static nrm_actuator_t *actuator;
 
-int nrm_dummy_extra_callback(nrm_uuid_t *uuid, double value)
+
+int nrm_dummy_extra_action_callback(nrm_uuid_t *uuid, double value)
 {
 	(void)uuid;
 	nrm_log_debug("action %f\n", value);
+	return 0;
+}
+
+int nrm_dummy_extra_timer_callback(nrm_reactor_t *reactor)
+{
+	nrm_time_t time;
+	nrm_time_gettime(&time);
+	nrm_client_send_event(client, time, sensor, scope, counter++);
 	return 0;
 }
 
@@ -67,9 +81,6 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	nrm_sensor_t *sensor;
-	nrm_scope_t *scope;
-	nrm_actuator_t *actuator;
 
 	nrm_log_info("creating dummy sensor\n");
 	sensor = nrm_sensor_create("nrm-dummy-extra-sensor");
@@ -100,25 +111,29 @@ int main(int argc, char *argv[])
 	}
 
 	nrm_log_info("starting dummy actuate callback\n");
-	nrm_client_set_actuate_listener(client, nrm_dummy_extra_callback);
+	nrm_client_set_actuate_listener(client, nrm_dummy_extra_action_callback);
 	nrm_client_start_actuate_listener(client);
 
-	uint64_t counter = 0;
-	while (1) {
-		nrm_time_t time;
-		nrm_time_gettime(&time);
-		nrm_client_send_event(client, time, sensor, scope, counter++);
-
-		/* sleep */
-		struct timespec req, rem;
-		req = nrm_time_fromfreq(args.freq);
-		/* possible signal interrupt here */
-		err = nanosleep(&req, &rem);
-		if (err == -1 && errno == EINTR) {
-			nrm_log_error("interupted during sleep, exiting\n");
-			break;
-		}
+	err = nrm_reactor_create(&reactor);
+	if (err) {
+		nrm_log_error("error during reactor creation\n");
+		return EXIT_FAILURE;
 	}
+	
+	nrm_reactor_user_callbacks_t callbacks = {
+		.signal = NULL,
+		.timer = nrm_dummy_extra_timer_callback,
+	};
+	nrm_reactor_setcallbacks(reactor, callbacks);
+
+	nrm_time_t sleeptime = nrm_time_fromfreq(args.freq);
+	nrm_reactor_settimer(reactor, sleeptime);
+
+	/* idle loop */
+	nrm_reactor_start(reactor);
+
+	nrm_reactor_destroy(&reactor);
+	/* cleanup, only get there if signal or error */
 	nrm_client_destroy(&client);
 	nrm_finalize();
 	return 0;

--- a/src/binaries/nrm-papiwrapper.c
+++ b/src/binaries/nrm-papiwrapper.c
@@ -85,7 +85,7 @@ int nrm_papiwrapper_timer_callback(nrm_reactor_t *reactor)
 	err = PAPI_read(EventSet, counters);
 	if (err != PAPI_OK) {
 		nrm_log_error("PAPI event read error: %s\n",
-				PAPI_strerror(err));
+		              PAPI_strerror(err));
 		return -1;
 	}
 	nrm_log_debug("PAPI counters read.\n");
@@ -95,12 +95,10 @@ int nrm_papiwrapper_timer_callback(nrm_reactor_t *reactor)
 
 	for (size_t i = 0; i < EventCodeCnt; i++) {
 		nrm_sensor_t **sensor;
-		nrm_vector_get_withtype(nrm_sensor_t *, sensors, i,
-				sensor);
+		nrm_vector_get_withtype(nrm_sensor_t *, sensors, i, sensor);
 		if (nrm_client_send_event(client, time, *sensor, scope,
-					counters[i]) != 0) {
-			nrm_log_error(
-					"Sending event to the daemon error\n");
+		                          counters[i]) != 0) {
+			nrm_log_error("Sending event to the daemon error\n");
 			return -1;
 		}
 	}
@@ -109,7 +107,7 @@ int nrm_papiwrapper_timer_callback(nrm_reactor_t *reactor)
 }
 
 int nrm_papiwrapper_signal_callback(nrm_reactor_t *reactor,
-		struct signalfd_siginfo fdsi)
+                                    struct signalfd_siginfo fdsi)
 {
 	(void)reactor;
 	nrm_log_debug("Received signal\n");

--- a/src/binaries/nrm-papiwrapper.c
+++ b/src/binaries/nrm-papiwrapper.c
@@ -31,6 +31,14 @@
 #include <time.h>
 #include <unistd.h>
 
+static int cmdpid;
+static nrm_client_t *client;
+static nrm_scope_t *scope;
+static nrm_vector_t *sensors = NULL;
+static long long *counters = NULL;
+static size_t EventCodeCnt = 0;
+static int EventSet = PAPI_NULL;
+
 int find_allowed_scope(nrm_client_t *client, nrm_scope_t **scope)
 {
 	/* create a scope based on hwloc_allowed, althouth we know for a fact
@@ -67,6 +75,64 @@ int find_allowed_scope(nrm_client_t *client, nrm_scope_t **scope)
 	return 0;
 }
 
+int nrm_papiwrapper_timer_callback(nrm_reactor_t *reactor)
+{
+	(void)reactor;
+	int err;
+	nrm_time_t time;
+
+	/* sample and report */
+	err = PAPI_read(EventSet, counters);
+	if (err != PAPI_OK) {
+		nrm_log_error("PAPI event read error: %s\n",
+				PAPI_strerror(err));
+		return -1;
+	}
+	nrm_log_debug("PAPI counters read.\n");
+
+	nrm_time_gettime(&time);
+	nrm_log_debug("NRM time obtained.\n");
+
+	for (size_t i = 0; i < EventCodeCnt; i++) {
+		nrm_sensor_t **sensor;
+		nrm_vector_get_withtype(nrm_sensor_t *, sensors, i,
+				sensor);
+		if (nrm_client_send_event(client, time, *sensor, scope,
+					counters[i]) != 0) {
+			nrm_log_error(
+					"Sending event to the daemon error\n");
+			return -1;
+		}
+	}
+	nrm_log_debug("NRM values sent.\n");
+	return 0;
+}
+
+int nrm_papiwrapper_signal_callback(nrm_reactor_t *reactor,
+		struct signalfd_siginfo fdsi)
+{
+	(void)reactor;
+	nrm_log_debug("Received signal\n");
+
+	/* exit immediately on SIGINT/SIGTERM */
+	if (fdsi.ssi_signo != SIGCHLD)
+		return -1;
+
+	nrm_log_debug("Signal info: %d %d\n", fdsi.ssi_signo, fdsi.ssi_pid);
+	/* ignore status updates on wrong pid */
+	if ((int)fdsi.ssi_pid != cmdpid)
+		return 0;
+
+	/* ignore stopped/restarted cmd */
+	if (fdsi.ssi_code == CLD_STOPPED || fdsi.ssi_code == CLD_CONTINUED)
+		return 0;
+
+	/* we're here if the child command exited, so end the program by
+	 * exiting the reactor
+	 */
+	return -1;
+}
+
 int main(int argc, char **argv)
 {
 	int err;
@@ -76,11 +142,6 @@ int main(int argc, char **argv)
 	nrm_log_init(stderr, "nrm-papiwrapper");
 
 	int ret = EXIT_FAILURE;
-	nrm_client_t *client;
-	nrm_scope_t *scope;
-	nrm_vector_t *sensors = NULL;
-	long long *counters = NULL;
-	size_t EventCodeCnt = 0;
 
 	args.progname = "nrm-papiwrapper";
 	args.flags = NRM_TOOLS_ARGS_FLAG_FREQ | NRM_TOOLS_ARGS_FLAG_EVENT;
@@ -187,7 +248,6 @@ int main(int argc, char **argv)
 	nrm_log_debug("PAPI initialized.\n");
 
 	/* set up PAPI interface */
-	int EventSet = PAPI_NULL;
 
 	err = PAPI_create_eventset(&EventSet);
 	if (err != PAPI_OK) {
@@ -215,14 +275,14 @@ int main(int argc, char **argv)
 
 		nrm_log_debug(
 		        "PAPI code string %s converted to PAPI code %i, and registered.\n",
-		        EventName, EventCode);
+		        *EventName, EventCode);
 	}
 
-	int pid = fork();
-	if (pid < 0) {
+	cmdpid = fork();
+	if (cmdpid < 0) {
 		nrm_log_error("fork error\n");
 		goto cleanup;
-	} else if (pid == 0) {
+	} else if (cmdpid == 0) {
 		/* child, needs to exec the cmd */
 		if (cmpinfo->attach_must_ptrace)
 			if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) == -1) {
@@ -241,7 +301,7 @@ int main(int argc, char **argv)
 		int status;
 
 		/* Wait for the child process to stop on execve(2).  */
-		if (waitpid(pid, &status, 0) == -1) {
+		if (waitpid(cmdpid, &status, 0) == -1) {
 			nrm_log_error("waitpid error: %s\n", strerror(errno));
 			goto cleanup;
 		}
@@ -254,13 +314,13 @@ int main(int argc, char **argv)
 	}
 
 	/* Need to attach counters to the child */
-	err = PAPI_attach(EventSet, pid);
+	err = PAPI_attach(EventSet, cmdpid);
 	if (err != PAPI_OK) {
 		nrm_log_error("PAPI eventset attach error: %s\n",
 		              PAPI_strerror(err));
 		goto cleanup;
 	}
-	nrm_log_debug("PAPI attached to process with pid %i\n", pid);
+	nrm_log_debug("PAPI attached to process with pid %i\n", cmdpid);
 
 	err = PAPI_start(EventSet);
 	if (err != PAPI_OK) {
@@ -275,59 +335,36 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGINT);
+	sigaddset(&sigmask, SIGTERM);
+	sigaddset(&sigmask, SIGCHLD);
+	nrm_reactor_t *reactor;
+	err = nrm_reactor_create(&reactor, &sigmask);
+	if (err) {
+		nrm_log_error("error during reactor creation\n");
+		goto cleanup;
+	}
+
+	nrm_reactor_user_callbacks_t callbacks = {
+	        .signal = nrm_papiwrapper_signal_callback,
+	        .timer = nrm_papiwrapper_timer_callback,
+	};
+	nrm_reactor_setcallbacks(reactor, callbacks);
+
+	nrm_time_t sleeptime = nrm_time_fromfreq(args.freq);
+	nrm_reactor_settimer(reactor, sleeptime);
+
 	if (cmpinfo->attach_must_ptrace) {
 		/* Let the child continue with execve(2).  */
-		if (ptrace(PTRACE_CONT, pid, NULL, NULL) == -1) {
+		if (ptrace(PTRACE_CONT, cmdpid, NULL, NULL) == -1) {
 			nrm_log_error("ptrace(PTRACE_TRACEME) failed\n");
 			goto cleanup;
 		}
 	}
 
-	do {
-		/* sleep for a frequency */
-		long long sleeptime = 1e9 / args.freq;
-		struct timespec req, rem;
-		req.tv_sec = sleeptime / 1000000000;
-		req.tv_nsec = sleeptime % 1000000000;
-		/* deal with signal interrupts */
-		do {
-			err = nanosleep(&req, &rem);
-			req = rem;
-		} while (err == -1 && errno == EINTR);
-
-		/* sample and report */
-		err = PAPI_read(EventSet, counters);
-		if (err != PAPI_OK) {
-			nrm_log_error("PAPI event read error: %s\n",
-			              PAPI_strerror(err));
-			goto cleanup;
-		}
-		nrm_log_debug("PAPI counters read.\n");
-
-		nrm_time_gettime(&time);
-		nrm_log_debug("NRM time obtained.\n");
-
-		for (size_t i = 0; i < EventCodeCnt; i++) {
-			nrm_sensor_t **sensor;
-			nrm_vector_get_withtype(nrm_sensor_t *, sensors, i,
-			                        sensor);
-			if (nrm_client_send_event(client, time, *sensor, scope,
-			                          counters[i]) != 0) {
-				nrm_log_error(
-				        "Sending event to the daemon error\n");
-				goto cleanup;
-			}
-		}
-		nrm_log_debug("NRM values sent.\n");
-
-		/* loop until child exits */
-		int status;
-		err = waitpid(pid, &status, WNOHANG);
-		if (err == -1) {
-			nrm_log_error("waitpid error: %s\n", strerror(errno));
-			goto cleanup;
-		}
-	} while (err != pid);
+	nrm_reactor_start(reactor);
 	ret = EXIT_SUCCESS;
 	nrm_log_debug("Finalizing PAPI-event read/send to NRM.\n");
 

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -327,11 +327,14 @@ int cmd_listen(int argc, char **argv)
 	nrm_client_set_event_listener(client, client_listen_callback);
 	nrm_client_start_event_listener(client, topic);
 
-	/* don't want to push a message queue into the user API, so do it this
-	 * way. The callback will take care of printing events.
-	 */
-	while (1)
-		;
+	nrm_reactor_t *reactor;
+	nrm_reactor_create(&reactor);
+	
+	/* idle loop */
+	nrm_reactor_start(reactor);
+
+	/* cleanup, only get there if signal or error */
+	nrm_reactor_destroy(&reactor);
 	return 0;
 }
 

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -328,11 +328,7 @@ int cmd_listen(int argc, char **argv)
 	nrm_client_start_event_listener(client, topic);
 
 	nrm_reactor_t *reactor;
-	sigset_t sigmask;
-	sigemptyset(&sigmask);
-	sigaddset(&sigmask, SIGINT);
-	sigaddset(&sigmask, SIGTERM);
-	nrm_reactor_create(&reactor, sigmask);
+	nrm_reactor_create(&reactor, NULL);
 
 	/* idle loop */
 	nrm_reactor_start(reactor);

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -329,7 +329,7 @@ int cmd_listen(int argc, char **argv)
 
 	nrm_reactor_t *reactor;
 	nrm_reactor_create(&reactor);
-	
+
 	/* idle loop */
 	nrm_reactor_start(reactor);
 

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -328,7 +328,11 @@ int cmd_listen(int argc, char **argv)
 	nrm_client_start_event_listener(client, topic);
 
 	nrm_reactor_t *reactor;
-	nrm_reactor_create(&reactor);
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGINT);
+	sigaddset(&sigmask, SIGTERM);
+	nrm_reactor_create(&reactor, sigmask);
 
 	/* idle loop */
 	nrm_reactor_start(reactor);

--- a/src/client.c
+++ b/src/client.c
@@ -693,7 +693,6 @@ int nrm_client_send_event(const nrm_client_t *client,
 	pthread_mutex_lock(&(client->lock));
 	nrm_role_send(client->role, msg, NULL);
 	pthread_mutex_unlock(&(client->lock));
-
 	return 0;
 }
 

--- a/src/nrm.c
+++ b/src/nrm.c
@@ -91,6 +91,9 @@ int nrm_init(int *argc, char **argv[])
 			return err;
 		}
 	}
+
+	/* disable signal handling by zmq */
+	zsys_handler_set(NULL);
 	return 0;
 }
 

--- a/src/python/nrm-setup.py
+++ b/src/python/nrm-setup.py
@@ -103,7 +103,7 @@ signal.signal(signal.SIGCHLD, handler.child_handler)
 
 tolaunch = []
 if args.dummy:
-    nrm_dummy_extra = NRMBinary("nrm-dummy-extra", False)
+    nrm_dummy_extra = NRMBinary("nrm-dummy-extra", True)
     tolaunch.append(nrm_dummy_extra)
 
 handler.launch(args, nrmd, tolaunch)

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -25,7 +25,9 @@ struct nrm_reactor_s {
 	nrm_reactor_user_callbacks_t callbacks;
 };
 
-int nrm_reactor_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
+int nrm_reactor_signal_callback(zloop_t *loop,
+                                zmq_pollitem_t *poller,
+                                void *arg)
 {
 	(void)loop;
 	nrm_reactor_t *self = (nrm_reactor_t *)arg;
@@ -104,7 +106,7 @@ err_reactor:
 }
 
 int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
-                            nrm_reactor_user_callbacks_t callbacks)
+                             nrm_reactor_user_callbacks_t callbacks)
 {
 	if (reactor == NULL)
 		return -NRM_EINVAL;

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -76,7 +76,7 @@ int nrm_reactor_create(nrm_reactor_t **reactor)
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGINT);
 	sigaddset(&sigmask, SIGTERM);
-	err = sigprocmask(SIG_BLOCK, &sigmask, &ret->oldmask);
+	err = pthread_sigmask(SIG_BLOCK, &sigmask, &ret->oldmask);
 	if (err == -1) {
 		err = -errno;
 		goto err_zloop;
@@ -138,7 +138,7 @@ void nrm_reactor_destroy(nrm_reactor_t **reactor)
 		return;
 	nrm_reactor_t *r = *reactor;
 	zloop_destroy(&r->loop);
-	sigprocmask(SIG_SETMASK, &r->oldmask, NULL);
+	pthread_sigmask(SIG_SETMASK, &r->oldmask, NULL);
 	free(r);
 	*reactor = NULL;
 }

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the libnrm project.
+ * For more info, see https://github.com/anlsys/libnrm
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+#include "config.h"
+
+#include "nrm.h"
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/signalfd.h>
+
+#include "internal/nrmi.h"
+
+struct nrm_reactor_s {
+	zloop_t *loop;
+	nrm_reactor_user_callbacks_t callbacks;
+};
+
+int nrm_reactor_signal_callback(zloop_t *loop, zmq_pollitem_t *poller, void *arg)
+{
+	(void)loop;
+	nrm_reactor_t *self = (nrm_reactor_t *)arg;
+	struct signalfd_siginfo fdsi;
+	ssize_t s = read(poller->fd, &fdsi, sizeof(struct signalfd_siginfo));
+	assert(s == sizeof(struct signalfd_siginfo));
+	int signalid = fdsi.ssi_signo;
+	nrm_log_debug("caught signal %d\n", signalid);
+
+	/* we default to exit */
+	int ret = -1;
+	if (self->callbacks.signal != NULL)
+		ret = self->callbacks.signal(self, signalid);
+	return ret;
+}
+
+int nrm_reactor_timer_callback(zloop_t *loop, int timerid, void *arg)
+{
+	(void)loop;
+	(void)timerid;
+	nrm_reactor_t *self = (nrm_reactor_t *)arg;
+
+	int ret = 0;
+	if (self->callbacks.timer != NULL)
+		ret = self->callbacks.timer(self);
+	return ret;
+}
+
+int nrm_reactor_create(nrm_reactor_t **reactor)
+{
+	if (reactor == NULL)
+		return -NRM_EINVAL;
+
+	nrm_reactor_t *ret = calloc(1, sizeof(nrm_reactor_t));
+	if (ret == NULL)
+		return -NRM_ENOMEM;
+
+	ret->loop = zloop_new();
+	assert(ret->loop != NULL);
+
+	/* we always setup signal handling and controller callback */
+	sigset_t sigmask;
+	sigemptyset(&sigmask);
+	sigaddset(&sigmask, SIGINT);
+	int sfd = signalfd(-1, &sigmask, 0);
+	assert(sfd != -1);
+	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN, 0};
+	zloop_poller(ret->loop, &signal_poller, nrm_reactor_signal_callback,
+	             NULL);
+
+	*reactor = ret;
+	return 0;
+}
+
+int nrm_reactor_setcallbacks(nrm_reactor_t *reactor,
+                            nrm_reactor_user_callbacks_t callbacks)
+{
+	if (reactor == NULL)
+		return -NRM_EINVAL;
+
+	reactor->callbacks = callbacks;
+	return 0;
+}
+
+int nrm_reactor_settimer(nrm_reactor_t *reactor, nrm_time_t sleeptime)
+{
+	if (reactor == NULL)
+		return -NRM_EINVAL;
+
+	int millisecs = sleeptime.tv_sec * 1e3 + sleeptime.tv_nsec * 1e6;
+	zloop_timer(reactor->loop, millisecs, 0, nrm_reactor_timer_callback,
+	            reactor);
+	return 0;
+}
+
+int nrm_reactor_start(nrm_reactor_t *reactor)
+{
+	if (reactor == NULL)
+		return -NRM_EINVAL;
+
+	return zloop_start(reactor->loop);
+}
+
+void nrm_reactor_destroy(nrm_reactor_t **reactor)
+{
+	if (reactor == NULL || *reactor == NULL)
+		return;
+	nrm_reactor_t *r = *reactor;
+	zloop_destroy(&r->loop);
+	free(r);
+	*reactor = NULL;
+}

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -56,7 +56,7 @@ int nrm_reactor_timer_callback(zloop_t *loop, int timerid, void *arg)
 	return ret;
 }
 
-int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t sigmask)
+int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t *sigmask)
 {
 	int err;
 
@@ -71,6 +71,14 @@ int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t sigmask)
 	if (ret->loop == NULL) {
 		err = -errno;
 		goto err_reactor;
+	}
+
+	sigset_t dmask;
+	if (sigmask == NULL) {
+		sigemptyset(&dmask);
+		sigaddset(&dmask, SIGINT);
+		sigaddset(&dmask, SIGTERM);
+		sigmask = &dmask;
 	}
 
 	/* we always setup signal handling */

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -81,15 +81,15 @@ int nrm_reactor_create(nrm_reactor_t **reactor, sigset_t *sigmask)
 		sigmask = &dmask;
 	}
 
-	int sfd = signalfd(-1, sigmask, 0);
-	if (sfd == -1) {
+	/* we always setup signal handling */
+	err = pthread_sigmask(SIG_BLOCK, sigmask, &ret->oldmask);
+	if (err == -1) {
 		err = -errno;
 		goto err_zloop;
 	}
 
-	/* we always setup signal handling */
-	err = pthread_sigmask(SIG_BLOCK, sigmask, &ret->oldmask);
-	if (err == -1) {
+	int sfd = signalfd(-1, sigmask, 0);
+	if (sfd == -1) {
 		err = -errno;
 		goto err_mask;
 	}
@@ -124,7 +124,7 @@ int nrm_reactor_settimer(nrm_reactor_t *reactor, nrm_time_t sleeptime)
 	if (reactor == NULL)
 		return -NRM_EINVAL;
 
-	int millisecs = sleeptime.tv_sec * 1e3 + sleeptime.tv_nsec / 1e6;
+	int millisecs = sleeptime.tv_sec * 1000 + sleeptime.tv_nsec / 1000000;
 	zloop_timer(reactor->loop, millisecs, 0, nrm_reactor_timer_callback,
 	            reactor);
 	return 0;

--- a/src/server.c
+++ b/src/server.c
@@ -368,11 +368,13 @@ int nrm_server_create(nrm_server_t **server,
 	sigset_t sigmask;
 	sigemptyset(&sigmask);
 	sigaddset(&sigmask, SIGINT);
+	sigaddset(&sigmask, SIGTERM);
+	sigprocmask(SIG_BLOCK, &sigmask, NULL);
 	int sfd = signalfd(-1, &sigmask, 0);
 	assert(sfd != -1);
 	zmq_pollitem_t signal_poller = {0, sfd, ZMQ_POLLIN, 0};
 	zloop_poller(ret->loop, &signal_poller, nrm_server_signal_callback,
-	             NULL);
+	             ret);
 
 	nrm_role_controller_register_recvcallback(
 	        ret->role, ret->loop, nrm_server_role_callback, ret);

--- a/tests/cli/full-setup.bats
+++ b/tests/cli/full-setup.bats
@@ -4,6 +4,10 @@
 setup_file() {
 	nrm-setup -p $ABS_TOP_BUILDDIR -o $BATS_FILE_TMPDIR --dummy &
 	NRM_SETUP_PID=$!
+	# wait for nrm-setup to start sleeping
+	while [ `ps -q $NRM_SETUP_PID -o stat= | cut -c1` != "S" ]; do
+		sleep 0.1
+	done
 }
 
 @test "server connect" {

--- a/tests/cli/full-setup.bats
+++ b/tests/cli/full-setup.bats
@@ -5,9 +5,7 @@ setup_file() {
 	nrm-setup -p $ABS_TOP_BUILDDIR -o $BATS_FILE_TMPDIR --dummy &
 	NRM_SETUP_PID=$!
 	# wait for nrm-setup to start sleeping
-	while [ `ps -q $NRM_SETUP_PID -o stat= | cut -c1` != "S" ]; do
-		sleep 0.1
-	done
+	sleep 1
 }
 
 @test "server connect" {


### PR DESCRIPTION
Reactor pattern, only for signals and timers, can be used at the same time as clients, and makes dummy-extra and others killable cleanly.

Related to #75 #61 #60 