### PR TITLE
[fix] compiler warnings

### DIFF
--- a/include/nrm.h
+++ b/include/nrm.h
@@ -302,8 +302,7 @@ int nrm_client_actuate(nrm_client_t *client,
                        nrm_actuator_t *actuator,
                        double value);
 
-int nrm_client_add_actuator(nrm_client_t *client,
-                            nrm_actuator_t *actuator);
+int nrm_client_add_actuator(nrm_client_t *client, nrm_actuator_t *actuator);
 
 /**
  * Adds an NRM scope to an NRM client.
@@ -336,8 +335,7 @@ int nrm_client_find(nrm_client_t *client,
                     const char *uuid,
                     nrm_vector_t **results);
 
-int nrm_client_list_actuators(nrm_client_t *client,
-                              nrm_vector_t **actuators);
+int nrm_client_list_actuators(nrm_client_t *client, nrm_vector_t **actuators);
 
 /**
  * Lists an NRM client's registered scopes into a vector
@@ -361,8 +359,7 @@ int nrm_client_list_slices(nrm_client_t *client, nrm_vector_t **slices);
  * Removes an NRM actuator from a daemon
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove_actuator(nrm_client_t *client,
-                               nrm_actuator_t *actuator);
+int nrm_client_remove_actuator(nrm_client_t *client, nrm_actuator_t *actuator);
 
 /**
  * Removes an NRM slice from a daemon

--- a/include/nrm.h
+++ b/include/nrm.h
@@ -298,30 +298,30 @@ int nrm_client_create(nrm_client_t **client,
                       int pub_port,
                       int rpc_port);
 
-int nrm_client_actuate(const nrm_client_t *client,
+int nrm_client_actuate(nrm_client_t *client,
                        nrm_actuator_t *actuator,
                        double value);
 
-int nrm_client_add_actuator(const nrm_client_t *client,
+int nrm_client_add_actuator(nrm_client_t *client,
                             nrm_actuator_t *actuator);
 
 /**
  * Adds an NRM scope to an NRM client.
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope);
+int nrm_client_add_scope(nrm_client_t *client, nrm_scope_t *scope);
 
 /**
  * Adds an NRM sensor to an NRM client.
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_add_sensor(const nrm_client_t *client, nrm_sensor_t *sensor);
+int nrm_client_add_sensor(nrm_client_t *client, nrm_sensor_t *sensor);
 
 /**
  * Adds an NRM slice to an NRM client.
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice);
+int nrm_client_add_slice(nrm_client_t *client, nrm_slice_t *slice);
 
 /**
  * Find matching NRM objects within a client
@@ -331,56 +331,56 @@ int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice);
  * @param results: NRM vector for containing results
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_find(const nrm_client_t *client,
+int nrm_client_find(nrm_client_t *client,
                     int type,
                     const char *uuid,
                     nrm_vector_t **results);
 
-int nrm_client_list_actuators(const nrm_client_t *client,
+int nrm_client_list_actuators(nrm_client_t *client,
                               nrm_vector_t **actuators);
 
 /**
  * Lists an NRM client's registered scopes into a vector
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_list_scopes(const nrm_client_t *client, nrm_vector_t **scopes);
+int nrm_client_list_scopes(nrm_client_t *client, nrm_vector_t **scopes);
 
 /**
  * Lists an NRM client's registered sensors into a vector
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_list_sensors(const nrm_client_t *client, nrm_vector_t **sensors);
+int nrm_client_list_sensors(nrm_client_t *client, nrm_vector_t **sensors);
 
 /**
  * Lists an NRM client's registered slices into a vector
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_list_slices(const nrm_client_t *client, nrm_vector_t **slices);
+int nrm_client_list_slices(nrm_client_t *client, nrm_vector_t **slices);
 
 /**
  * Removes an NRM actuator from a daemon
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove_actuator(const nrm_client_t *client,
+int nrm_client_remove_actuator(nrm_client_t *client,
                                nrm_actuator_t *actuator);
 
 /**
  * Removes an NRM slice from a daemon
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove_slice(const nrm_client_t *client, nrm_slice_t *slice);
+int nrm_client_remove_slice(nrm_client_t *client, nrm_slice_t *slice);
 
 /**
  * Removes an NRM sensor from a daemon
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove_sensor(const nrm_client_t *client, nrm_sensor_t *sensor);
+int nrm_client_remove_sensor(nrm_client_t *client, nrm_sensor_t *sensor);
 
 /**
  * Removes an NRM scope from a daemon
  * @return 0 if successful, an error code otherwise
  */
-int nrm_client_remove_scope(const nrm_client_t *client, nrm_scope_t *scope);
+int nrm_client_remove_scope(nrm_client_t *client, nrm_scope_t *scope);
 
 /**
  * Sends a measurement to the NRM daemon
@@ -393,7 +393,7 @@ int nrm_client_remove_scope(const nrm_client_t *client, nrm_scope_t *scope);
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_client_send_event(const nrm_client_t *client,
+int nrm_client_send_event(nrm_client_t *client,
                           nrm_time_t time,
                           nrm_sensor_t *sensor,
                           nrm_scope_t *scope,
@@ -406,7 +406,7 @@ int nrm_client_send_event(const nrm_client_t *client,
  * @return 0 if successful, an error code otherwise
  *
  */
-int nrm_client_send_exit(const nrm_client_t *client);
+int nrm_client_send_exit(nrm_client_t *client);
 
 /**
  * Set a callback function for client events

--- a/shell.nix
+++ b/shell.nix
@@ -25,5 +25,5 @@ mkShell {
   GEOPM_CFLAGS = "-I${geopmd}/include";
   GEOPM_LIBS = "-L${geopmd}/lib -lgeopmd";
   CFLAGS =
-    "-std=c99 -pedantic -Wall -Wextra -g -O0";
+    "-std=c17 -Wall -Wextra -Werror -Wno-builtin-declaration-mismatch";
 }

--- a/src/client.c
+++ b/src/client.c
@@ -48,7 +48,7 @@ int nrm_client_create(nrm_client_t **client,
 	return 0;
 }
 
-int nrm_client_actuate(const nrm_client_t *client,
+int nrm_client_actuate(nrm_client_t *client,
                        nrm_actuator_t *actuator,
                        double value)
 {
@@ -95,7 +95,7 @@ int nrm_client_actuate(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_add_actuator(const nrm_client_t *client,
+int nrm_client_add_actuator(nrm_client_t *client,
                             nrm_actuator_t *actuator)
 {
 	if (client == NULL || actuator == NULL)
@@ -127,7 +127,7 @@ int nrm_client_add_actuator(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope)
+int nrm_client_add_scope(nrm_client_t *client, nrm_scope_t *scope)
 {
 	if (client == NULL || scope == NULL)
 		return -NRM_EINVAL;
@@ -158,7 +158,7 @@ int nrm_client_add_scope(const nrm_client_t *client, nrm_scope_t *scope)
 	return 0;
 }
 
-int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice)
+int nrm_client_add_slice(nrm_client_t *client, nrm_slice_t *slice)
 {
 	if (client == NULL || slice == NULL)
 		return -NRM_EINVAL;
@@ -189,7 +189,7 @@ int nrm_client_add_slice(const nrm_client_t *client, nrm_slice_t *slice)
 	return 0;
 }
 
-int nrm_client_add_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
+int nrm_client_add_sensor(nrm_client_t *client, nrm_sensor_t *sensor)
 {
 	if (client == NULL || sensor == NULL)
 		return -NRM_EINVAL;
@@ -220,7 +220,7 @@ int nrm_client_add_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
 	return 0;
 }
 
-int nrm_client_find(const nrm_client_t *client,
+int nrm_client_find(nrm_client_t *client,
                     int type,
                     const char *uuid,
                     nrm_vector_t **results)
@@ -389,7 +389,7 @@ int nrm_client_start_actuate_listener(const nrm_client_t *client)
 	return 0;
 }
 
-int nrm_client_list_actuators(const nrm_client_t *client,
+int nrm_client_list_actuators(nrm_client_t *client,
                               nrm_vector_t **actuators)
 {
 	if (client == NULL || actuators == NULL)
@@ -432,7 +432,7 @@ int nrm_client_list_actuators(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_list_scopes(const nrm_client_t *client, nrm_vector_t **scopes)
+int nrm_client_list_scopes(nrm_client_t *client, nrm_vector_t **scopes)
 {
 	if (client == NULL || scopes == NULL)
 		return -NRM_EINVAL;
@@ -474,7 +474,7 @@ int nrm_client_list_scopes(const nrm_client_t *client, nrm_vector_t **scopes)
 	return 0;
 }
 
-int nrm_client_list_sensors(const nrm_client_t *client, nrm_vector_t **sensors)
+int nrm_client_list_sensors(nrm_client_t *client, nrm_vector_t **sensors)
 {
 	if (client == NULL || sensors == NULL)
 		return -NRM_EINVAL;
@@ -516,7 +516,7 @@ int nrm_client_list_sensors(const nrm_client_t *client, nrm_vector_t **sensors)
 	return 0;
 }
 
-int nrm_client_list_slices(const nrm_client_t *client, nrm_vector_t **slices)
+int nrm_client_list_slices(nrm_client_t *client, nrm_vector_t **slices)
 {
 	if (client == NULL || slices == NULL)
 		return -NRM_EINVAL;
@@ -558,7 +558,7 @@ int nrm_client_list_slices(const nrm_client_t *client, nrm_vector_t **slices)
 	return 0;
 }
 
-int nrm_client_remove_actuator(const nrm_client_t *client,
+int nrm_client_remove_actuator(nrm_client_t *client,
                                nrm_actuator_t *actuator)
 {
 	if (client == NULL || actuator == NULL)
@@ -588,7 +588,7 @@ int nrm_client_remove_actuator(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_remove_scope(const nrm_client_t *client, nrm_scope_t *scope)
+int nrm_client_remove_scope(nrm_client_t *client, nrm_scope_t *scope)
 {
 	if (client == NULL || scope == NULL)
 		return -NRM_EINVAL;
@@ -617,7 +617,7 @@ int nrm_client_remove_scope(const nrm_client_t *client, nrm_scope_t *scope)
 	return 0;
 }
 
-int nrm_client_remove_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
+int nrm_client_remove_sensor(nrm_client_t *client, nrm_sensor_t *sensor)
 {
 	if (client == NULL || sensor == NULL)
 		return -NRM_EINVAL;
@@ -646,7 +646,7 @@ int nrm_client_remove_sensor(const nrm_client_t *client, nrm_sensor_t *sensor)
 	return 0;
 }
 
-int nrm_client_remove_slice(const nrm_client_t *client, nrm_slice_t *slice)
+int nrm_client_remove_slice(nrm_client_t *client, nrm_slice_t *slice)
 {
 	if (client == NULL || slice == NULL)
 		return -NRM_EINVAL;
@@ -675,7 +675,7 @@ int nrm_client_remove_slice(const nrm_client_t *client, nrm_slice_t *slice)
 	return 0;
 }
 
-int nrm_client_send_event(const nrm_client_t *client,
+int nrm_client_send_event(nrm_client_t *client,
                           nrm_time_t time,
                           nrm_sensor_t *sensor,
                           nrm_scope_t *scope,
@@ -696,7 +696,7 @@ int nrm_client_send_event(const nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_send_exit(const nrm_client_t *client)
+int nrm_client_send_exit(nrm_client_t *client)
 {
 	if (client == NULL)
 		return -NRM_EINVAL;

--- a/src/client.c
+++ b/src/client.c
@@ -95,8 +95,7 @@ int nrm_client_actuate(nrm_client_t *client,
 	return 0;
 }
 
-int nrm_client_add_actuator(nrm_client_t *client,
-                            nrm_actuator_t *actuator)
+int nrm_client_add_actuator(nrm_client_t *client, nrm_actuator_t *actuator)
 {
 	if (client == NULL || actuator == NULL)
 		return -NRM_EINVAL;
@@ -389,8 +388,7 @@ int nrm_client_start_actuate_listener(const nrm_client_t *client)
 	return 0;
 }
 
-int nrm_client_list_actuators(nrm_client_t *client,
-                              nrm_vector_t **actuators)
+int nrm_client_list_actuators(nrm_client_t *client, nrm_vector_t **actuators)
 {
 	if (client == NULL || actuators == NULL)
 		return -NRM_EINVAL;
@@ -558,8 +556,7 @@ int nrm_client_list_slices(nrm_client_t *client, nrm_vector_t **slices)
 	return 0;
 }
 
-int nrm_client_remove_actuator(nrm_client_t *client,
-                               nrm_actuator_t *actuator)
+int nrm_client_remove_actuator(nrm_client_t *client, nrm_actuator_t *actuator)
 {
 	if (client == NULL || actuator == NULL)
 		return -NRM_EINVAL;

--- a/src/control/europar21.c
+++ b/src/control/europar21.c
@@ -144,6 +144,7 @@ int nrm_control_europar21_action(nrm_control_t *control,
 	if (in == NULL)
 		return -NRM_EINVAL;
 	pow = in->value;
+	(void)pow;
 	nrm_vector_get_withtype(nrm_control_output_t, outputs, 0, out);
 	if (out == NULL)
 		return -NRM_EINVAL;

--- a/src/messages.c
+++ b/src/messages.c
@@ -1167,6 +1167,7 @@ nrm_msg_t *nrm_ctrlmsg_recvmsg(zsock_t *socket, int *type, nrm_uuid_t **from)
 	int err;
 	void *p, *q;
 	err = nrm_ctrlmsg__recv(socket, type, &p, &q);
+	assert(err == 0);
 	nrm_log_printmsg(NRM_LOG_DEBUG, (nrm_msg_t *)p);
 	if (from != NULL) {
 		*from = (nrm_uuid_t *)q;

--- a/src/preloads/ompt/entrypoint.c
+++ b/src/preloads/ompt/entrypoint.c
@@ -68,7 +68,8 @@ int nrm_ompt_initialize(ompt_function_lookup_t lookup,
                         int initial_device_num,
                         ompt_data_t *tool_data)
 {
-	ompt_set_result_t ret;
+	(void)initial_device_num;
+	(void)tool_data;
 
 	nrm_init(NULL, NULL);
 	nrm_log_init(stderr, "nrm-ompt");
@@ -115,6 +116,7 @@ int nrm_ompt_initialize(ompt_function_lookup_t lookup,
 
 void nrm_ompt_finalize(ompt_data_t *tool_data)
 {
+	(void)tool_data;
 	nrm_log_debug("finalize tool\n");
 	nrm_scope_destroy(global_scope);
 	nrm_client_remove_sensor(global_client, global_sensor);

--- a/src/preloads/ompt/nrm_omp_callbacks.c
+++ b/src/preloads/ompt/nrm_omp_callbacks.c
@@ -33,12 +33,12 @@ void nrm_ompt_callback_parallel_begin_cb(
         int flags,
         const void *codeptr_ra)
 {
-	(void) encountering_task_data;
-	(void) encountering_task_frame;
-	(void) parallel_data;
-	(void) requested_parallelism;
-	(void) flags;
-	(void) codeptr_ra;
+	(void)encountering_task_data;
+	(void)encountering_task_frame;
+	(void)parallel_data;
+	(void)requested_parallelism;
+	(void)flags;
+	(void)codeptr_ra;
 
 	nrm_time_t nrmtime;
 	nrm_time_gettime(&nrmtime);
@@ -51,10 +51,10 @@ void nrm_ompt_callback_parallel_end_cb(ompt_data_t *parallel_data,
                                        int flags,
                                        const void *codeptr_ra)
 {
-	(void) parallel_data;
-	(void) encountering_task_data;
-	(void) flags;
-	(void) codeptr_ra;
+	(void)parallel_data;
+	(void)encountering_task_data;
+	(void)flags;
+	(void)codeptr_ra;
 	nrm_time_t nrmtime;
 	nrm_time_gettime(&nrmtime);
 	nrm_client_send_event(global_client, nrmtime, global_sensor,
@@ -68,12 +68,12 @@ void nrm_ompt_callback_work_cb(ompt_work_t wstype,
                                uint64_t count,
                                const void *codeptr_ra)
 {
-	(void) wstype;
-	(void) endpoint;
-	(void) parallel_data;
-	(void) task_data;
-	(void) count;
-	(void) codeptr_ra;
+	(void)wstype;
+	(void)endpoint;
+	(void)parallel_data;
+	(void)task_data;
+	(void)count;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_dispatch_cb(ompt_data_t *parallel_data,
@@ -81,10 +81,10 @@ void nrm_ompt_callback_dispatch_cb(ompt_data_t *parallel_data,
                                    ompt_dispatch_t kind,
                                    ompt_data_t instance)
 {
-	(void) parallel_data;
-	(void) task_data;
-	(void) kind;
-	(void) instance;
+	(void)parallel_data;
+	(void)task_data;
+	(void)kind;
+	(void)instance;
 }
 
 void nrm_ompt_callback_task_create_cb(
@@ -95,37 +95,37 @@ void nrm_ompt_callback_task_create_cb(
         int has_dependences,
         const void *codeptr_ra)
 {
-	(void) encountering_task_data;
-	(void) encountering_task_frame;
-	(void) new_task_data;
-	(void) flags;
-	(void) has_dependences;
-	(void) codeptr_ra;
+	(void)encountering_task_data;
+	(void)encountering_task_frame;
+	(void)new_task_data;
+	(void)flags;
+	(void)has_dependences;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_dependences_cb(ompt_data_t *task_data,
                                       const ompt_dependence_t *deps,
                                       int ndeps)
 {
-	(void) task_data;
-	(void) deps;
-	(void) ndeps;
+	(void)task_data;
+	(void)deps;
+	(void)ndeps;
 }
 
 void nrm_ompt_callback_task_dependence_cb(ompt_data_t *src_task_data,
                                           ompt_data_t *sink_task_data)
 {
-	(void) src_task_data;
-	(void) sink_task_data;
+	(void)src_task_data;
+	(void)sink_task_data;
 }
 
 void nrm_ompt_callback_task_schedule_cb(ompt_data_t *prior_task_data,
                                         ompt_task_status_t prior_task_status,
                                         ompt_data_t *next_task_data)
 {
-	(void) prior_task_data;
-	(void) prior_task_status;
-	(void) next_task_data;
+	(void)prior_task_data;
+	(void)prior_task_status;
+	(void)next_task_data;
 }
 
 void nrm_ompt_callback_implicit_task_cb(ompt_scope_endpoint_t endpoint,
@@ -135,12 +135,12 @@ void nrm_ompt_callback_implicit_task_cb(ompt_scope_endpoint_t endpoint,
                                         unsigned int index,
                                         int flags)
 {
-	(void) endpoint;
-	(void) parallel_data;
-	(void) task_data;
-	(void) actual_parallelism;
-	(void) index;
-	(void) flags;
+	(void)endpoint;
+	(void)parallel_data;
+	(void)task_data;
+	(void)actual_parallelism;
+	(void)index;
+	(void)flags;
 }
 
 void nrm_ompt_callback_sync_region_cb(ompt_sync_region_t kind,
@@ -149,11 +149,11 @@ void nrm_ompt_callback_sync_region_cb(ompt_sync_region_t kind,
                                       ompt_data_t *task_data,
                                       const void *codeptr_ra)
 {
-	(void) kind;
-	(void) endpoint;
-	(void) parallel_data;
-	(void) task_data;
-	(void) codeptr_ra;
+	(void)kind;
+	(void)endpoint;
+	(void)parallel_data;
+	(void)task_data;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_mutex_acquire_cb(ompt_mutex_t kind,
@@ -162,36 +162,36 @@ void nrm_ompt_callback_mutex_acquire_cb(ompt_mutex_t kind,
                                         ompt_wait_id_t wait_id,
                                         const void *codeptr_ra)
 {
-	(void) kind;
-	(void) hint;
-	(void) impl;
-	(void) wait_id;
-	(void) codeptr_ra;
+	(void)kind;
+	(void)hint;
+	(void)impl;
+	(void)wait_id;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_nest_lock_cb(ompt_scope_endpoint_t endpoint,
                                     ompt_wait_id_t wait_id,
                                     const void *codeptr_ra)
 {
-	(void) endpoint;
-	(void) wait_id;
-	(void) codeptr_ra;
+	(void)endpoint;
+	(void)wait_id;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_flush_cb(ompt_data_t *thread_data,
                                 const void *codeptr_ra)
 {
-	(void) thread_data;
-	(void) codeptr_ra;
+	(void)thread_data;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_cancel_cb(ompt_data_t *task_data,
                                  int flags,
                                  const void *codeptr_ra)
 {
-	(void) task_data;
-	(void) flags;
-	(void) codeptr_ra;
+	(void)task_data;
+	(void)flags;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_device_initialize_cb(int device_num,
@@ -200,16 +200,16 @@ void nrm_ompt_callback_device_initialize_cb(int device_num,
                                             ompt_function_lookup_t lookup,
                                             const char *documentation)
 {
-	(void) device_num;
-	(void) type;
-	(void) device;
-	(void) lookup;
-	(void) documentation;
+	(void)device_num;
+	(void)type;
+	(void)device;
+	(void)lookup;
+	(void)documentation;
 }
 
 void nrm_ompt_callback_device_finalize_cb(int device_num)
 {
-	(void) device_num;
+	(void)device_num;
 }
 
 void nrm_ompt_callback_device_load_cb(int device_num,
@@ -221,20 +221,20 @@ void nrm_ompt_callback_device_load_cb(int device_num,
                                       void *device_addr,
                                       uint64_t module_id)
 {
-	(void) device_num;
-	(void) filename;
-	(void) offset_in_file;
-	(void) vma_in_file;
-	(void) bytes;
-	(void) host_addr;
-	(void) device_addr;
-	(void) module_id;
+	(void)device_num;
+	(void)filename;
+	(void)offset_in_file;
+	(void)vma_in_file;
+	(void)bytes;
+	(void)host_addr;
+	(void)device_addr;
+	(void)module_id;
 }
 
 void nrm_ompt_callback_device_unload_cb(int device_num, uint64_t module_id)
 {
-	(void) device_num;
-	(void) module_id;
+	(void)device_num;
+	(void)module_id;
 }
 
 void nrm_ompt_callback_target_data_op_cb(ompt_id_t target_id,
@@ -247,15 +247,15 @@ void nrm_ompt_callback_target_data_op_cb(ompt_id_t target_id,
                                          size_t bytes,
                                          const void *codeptr_ra)
 {
-	(void) target_id;
-	(void) host_op_id;
-	(void) optype;
-	(void) src_addr;
-	(void) src_device_num;
-	(void) dest_addr;
-	(void) dest_device_num;
-	(void) bytes;
-	(void) codeptr_ra;
+	(void)target_id;
+	(void)host_op_id;
+	(void)optype;
+	(void)src_addr;
+	(void)src_device_num;
+	(void)dest_addr;
+	(void)dest_device_num;
+	(void)bytes;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_target_cb(ompt_target_t kind,
@@ -265,12 +265,12 @@ void nrm_ompt_callback_target_cb(ompt_target_t kind,
                                  ompt_id_t target_id,
                                  const void *codeptr_ra)
 {
-	(void) kind;
-	(void) endpoint;
-	(void) device_num;
-	(void) task_data;
-	(void) target_id;
-	(void) codeptr_ra;
+	(void)kind;
+	(void)endpoint;
+	(void)device_num;
+	(void)task_data;
+	(void)target_id;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_target_map_cb(ompt_id_t target_id,
@@ -281,22 +281,22 @@ void nrm_ompt_callback_target_map_cb(ompt_id_t target_id,
                                      unsigned int *mapping_flags,
                                      const void *codeptr_ra)
 {
-	(void) target_id;
-	(void) nitems;
-	(void) host_addr;
-	(void) device_addr;
-	(void) bytes;
-	(void) mapping_flags;
-	(void) codeptr_ra;
+	(void)target_id;
+	(void)nitems;
+	(void)host_addr;
+	(void)device_addr;
+	(void)bytes;
+	(void)mapping_flags;
+	(void)codeptr_ra;
 }
 
 void nrm_ompt_callback_target_submit_cb(ompt_id_t target_id,
                                         ompt_id_t host_op_id,
                                         unsigned int requested_num_teams)
 {
-	(void) target_id;
-	(void) host_op_id;
-	(void) requested_num_teams;
+	(void)target_id;
+	(void)host_op_id;
+	(void)requested_num_teams;
 }
 
 int nrm_ompt_callback_control_tool_cb(uint64_t command,
@@ -304,9 +304,10 @@ int nrm_ompt_callback_control_tool_cb(uint64_t command,
                                       void *arg,
                                       const void *codeptr_ra)
 {
-	(void) command; (void) modifier;
-	(void) arg;
-	(void) codeptr_ra;
+	(void)command;
+	(void)modifier;
+	(void)arg;
+	(void)codeptr_ra;
 	return 0;
 }
 

--- a/src/preloads/ompt/nrm_omp_callbacks.c
+++ b/src/preloads/ompt/nrm_omp_callbacks.c
@@ -16,10 +16,13 @@
 void nrm_ompt_callback_thread_begin_cb(ompt_thread_t thread_type,
                                        ompt_data_t *thread_data)
 {
+	(void)thread_type;
+	(void)thread_data;
 }
 
 void nrm_ompt_callback_thread_end_cb(ompt_data_t *thread_data)
 {
+	(void)thread_data;
 }
 
 void nrm_ompt_callback_parallel_begin_cb(

--- a/src/preloads/ompt/nrm_omp_callbacks.c
+++ b/src/preloads/ompt/nrm_omp_callbacks.c
@@ -33,6 +33,13 @@ void nrm_ompt_callback_parallel_begin_cb(
         int flags,
         const void *codeptr_ra)
 {
+	(void) encountering_task_data;
+	(void) encountering_task_frame;
+	(void) parallel_data;
+	(void) requested_parallelism;
+	(void) flags;
+	(void) codeptr_ra;
+
 	nrm_time_t nrmtime;
 	nrm_time_gettime(&nrmtime);
 	nrm_client_send_event(global_client, nrmtime, global_sensor,
@@ -44,6 +51,10 @@ void nrm_ompt_callback_parallel_end_cb(ompt_data_t *parallel_data,
                                        int flags,
                                        const void *codeptr_ra)
 {
+	(void) parallel_data;
+	(void) encountering_task_data;
+	(void) flags;
+	(void) codeptr_ra;
 	nrm_time_t nrmtime;
 	nrm_time_gettime(&nrmtime);
 	nrm_client_send_event(global_client, nrmtime, global_sensor,
@@ -57,6 +68,12 @@ void nrm_ompt_callback_work_cb(ompt_work_t wstype,
                                uint64_t count,
                                const void *codeptr_ra)
 {
+	(void) wstype;
+	(void) endpoint;
+	(void) parallel_data;
+	(void) task_data;
+	(void) count;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_dispatch_cb(ompt_data_t *parallel_data,
@@ -64,6 +81,10 @@ void nrm_ompt_callback_dispatch_cb(ompt_data_t *parallel_data,
                                    ompt_dispatch_t kind,
                                    ompt_data_t instance)
 {
+	(void) parallel_data;
+	(void) task_data;
+	(void) kind;
+	(void) instance;
 }
 
 void nrm_ompt_callback_task_create_cb(
@@ -74,23 +95,37 @@ void nrm_ompt_callback_task_create_cb(
         int has_dependences,
         const void *codeptr_ra)
 {
+	(void) encountering_task_data;
+	(void) encountering_task_frame;
+	(void) new_task_data;
+	(void) flags;
+	(void) has_dependences;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_dependences_cb(ompt_data_t *task_data,
                                       const ompt_dependence_t *deps,
                                       int ndeps)
 {
+	(void) task_data;
+	(void) deps;
+	(void) ndeps;
 }
 
 void nrm_ompt_callback_task_dependence_cb(ompt_data_t *src_task_data,
                                           ompt_data_t *sink_task_data)
 {
+	(void) src_task_data;
+	(void) sink_task_data;
 }
 
 void nrm_ompt_callback_task_schedule_cb(ompt_data_t *prior_task_data,
                                         ompt_task_status_t prior_task_status,
                                         ompt_data_t *next_task_data)
 {
+	(void) prior_task_data;
+	(void) prior_task_status;
+	(void) next_task_data;
 }
 
 void nrm_ompt_callback_implicit_task_cb(ompt_scope_endpoint_t endpoint,
@@ -100,6 +135,12 @@ void nrm_ompt_callback_implicit_task_cb(ompt_scope_endpoint_t endpoint,
                                         unsigned int index,
                                         int flags)
 {
+	(void) endpoint;
+	(void) parallel_data;
+	(void) task_data;
+	(void) actual_parallelism;
+	(void) index;
+	(void) flags;
 }
 
 void nrm_ompt_callback_sync_region_cb(ompt_sync_region_t kind,
@@ -108,6 +149,11 @@ void nrm_ompt_callback_sync_region_cb(ompt_sync_region_t kind,
                                       ompt_data_t *task_data,
                                       const void *codeptr_ra)
 {
+	(void) kind;
+	(void) endpoint;
+	(void) parallel_data;
+	(void) task_data;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_mutex_acquire_cb(ompt_mutex_t kind,
@@ -116,23 +162,36 @@ void nrm_ompt_callback_mutex_acquire_cb(ompt_mutex_t kind,
                                         ompt_wait_id_t wait_id,
                                         const void *codeptr_ra)
 {
+	(void) kind;
+	(void) hint;
+	(void) impl;
+	(void) wait_id;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_nest_lock_cb(ompt_scope_endpoint_t endpoint,
                                     ompt_wait_id_t wait_id,
                                     const void *codeptr_ra)
 {
+	(void) endpoint;
+	(void) wait_id;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_flush_cb(ompt_data_t *thread_data,
                                 const void *codeptr_ra)
 {
+	(void) thread_data;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_cancel_cb(ompt_data_t *task_data,
                                  int flags,
                                  const void *codeptr_ra)
 {
+	(void) task_data;
+	(void) flags;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_device_initialize_cb(int device_num,
@@ -141,10 +200,16 @@ void nrm_ompt_callback_device_initialize_cb(int device_num,
                                             ompt_function_lookup_t lookup,
                                             const char *documentation)
 {
+	(void) device_num;
+	(void) type;
+	(void) device;
+	(void) lookup;
+	(void) documentation;
 }
 
 void nrm_ompt_callback_device_finalize_cb(int device_num)
 {
+	(void) device_num;
 }
 
 void nrm_ompt_callback_device_load_cb(int device_num,
@@ -156,10 +221,20 @@ void nrm_ompt_callback_device_load_cb(int device_num,
                                       void *device_addr,
                                       uint64_t module_id)
 {
+	(void) device_num;
+	(void) filename;
+	(void) offset_in_file;
+	(void) vma_in_file;
+	(void) bytes;
+	(void) host_addr;
+	(void) device_addr;
+	(void) module_id;
 }
 
 void nrm_ompt_callback_device_unload_cb(int device_num, uint64_t module_id)
 {
+	(void) device_num;
+	(void) module_id;
 }
 
 void nrm_ompt_callback_target_data_op_cb(ompt_id_t target_id,
@@ -172,6 +247,15 @@ void nrm_ompt_callback_target_data_op_cb(ompt_id_t target_id,
                                          size_t bytes,
                                          const void *codeptr_ra)
 {
+	(void) target_id;
+	(void) host_op_id;
+	(void) optype;
+	(void) src_addr;
+	(void) src_device_num;
+	(void) dest_addr;
+	(void) dest_device_num;
+	(void) bytes;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_target_cb(ompt_target_t kind,
@@ -181,6 +265,12 @@ void nrm_ompt_callback_target_cb(ompt_target_t kind,
                                  ompt_id_t target_id,
                                  const void *codeptr_ra)
 {
+	(void) kind;
+	(void) endpoint;
+	(void) device_num;
+	(void) task_data;
+	(void) target_id;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_target_map_cb(ompt_id_t target_id,
@@ -191,12 +281,22 @@ void nrm_ompt_callback_target_map_cb(ompt_id_t target_id,
                                      unsigned int *mapping_flags,
                                      const void *codeptr_ra)
 {
+	(void) target_id;
+	(void) nitems;
+	(void) host_addr;
+	(void) device_addr;
+	(void) bytes;
+	(void) mapping_flags;
+	(void) codeptr_ra;
 }
 
 void nrm_ompt_callback_target_submit_cb(ompt_id_t target_id,
                                         ompt_id_t host_op_id,
                                         unsigned int requested_num_teams)
 {
+	(void) target_id;
+	(void) host_op_id;
+	(void) requested_num_teams;
 }
 
 int nrm_ompt_callback_control_tool_cb(uint64_t command,
@@ -204,6 +304,10 @@ int nrm_ompt_callback_control_tool_cb(uint64_t command,
                                       void *arg,
                                       const void *codeptr_ra)
 {
+	(void) command; (void) modifier;
+	(void) arg;
+	(void) codeptr_ra;
+	return 0;
 }
 
 void nrm_ompt_register_cbs(void)

--- a/src/preloads/pmpi/mpi_api.c
+++ b/src/preloads/pmpi/mpi_api.c
@@ -20,7 +20,6 @@
  * efficiency of the node.
  */
 
-#define _GNU_SOURCE
 #include "nrm.h"
 #include <assert.h>
 #include <ctype.h>

--- a/src/roles/client.c
+++ b/src/roles/client.c
@@ -228,7 +228,6 @@ void nrm_client_broker_fn(zsock_t *pipe, void *args)
 	/* start: will only return when broker is destroyed */
 	zloop_start(self->loop);
 
-cleanup_loop:
 	zloop_destroy(&self->loop);
 cleanup_sub:
 	zsock_destroy(&self->sub);


### PR DESCRIPTION
Update the nix-shell to -std=c17 and compiler flags to -Werror so that we can enforce better compile rules.

Also fix related warnings/errors. Note that, as usual, autoconf requires no-declaration-mismatch.