### PR TITLE
[fix] Adjust PMPI preload path

### DIFF
--- a/src/preloads/ompt/entrypoint.c
+++ b/src/preloads/ompt/entrypoint.c
@@ -73,7 +73,6 @@ int nrm_ompt_initialize(ompt_function_lookup_t lookup,
 
 	nrm_init(NULL, NULL);
 	nrm_log_init(stderr, "nrm-ompt");
-	nrm_log_setlevel(NRM_LOG_DEBUG);
 	nrm_log_debug("initialize tool\n");
 
 	// initialize global client

--- a/tests/pmpi/pmpi.bats
+++ b/tests/pmpi/pmpi.bats
@@ -16,11 +16,11 @@ setup_file() {
 	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ls -al
 }
 
-@test "preload, basic omp" {
+@test "preload, basic mpi" {
 	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ./mpi_basic
 }
 
-@test "preload, stream omp" {
+@test "preload, collectives mpi" {
 	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ./mpi_collectives
 }
 

--- a/tests/pmpi/pmpi.bats
+++ b/tests/pmpi/pmpi.bats
@@ -13,15 +13,15 @@ setup_file() {
 }
 
 @test "preload, no callbacks" {
-	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/.libs/libnrm-pmpi.so ls -al
+	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ls -al
 }
 
 @test "preload, basic omp" {
-	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/.libs/libnrm-pmpi.so ./mpi_basic
+	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ./mpi_basic
 }
 
 @test "preload, stream omp" {
-	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/.libs/libnrm-pmpi.so ./mpi_collectives
+	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc -vvv run -d $ABS_TOP_BUILDDIR/src/preloads/pmpi/.libs/libnrm-pmpi.so ./mpi_collectives
 }
 
 teardown_file() {


### PR DESCRIPTION
Also fix the test names and comment out debugging output in OMPT preload.