### PR TITLE
[feature] quiet default sub, working listen

### DIFF
--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -348,21 +348,23 @@ int client_listen_callback(nrm_string_t sensor_uuid,
                            nrm_scope_t *scope,
                            double value)
 {
-	(void)sensor_uuid;
-	(void)time;
-	(void)scope;
-	(void)value;
-	nrm_log_debug("event\n");
+	int64_t nstime = nrm_time_tons(&time);
+	fprintf(stdout, "event: %" PRId64 " %s %s %f\n", nstime, sensor_uuid,
+			scope->uuid, value);
 	return 0;
 }
 
 int cmd_listen(int argc, char **argv)
 {
-	/* no options at this time */
-	if (argc < 1)
+	/* optionally a topic */
+	if (argc > 2)
 		return EXIT_FAILURE;
 
-	nrm_string_t topic = nrm_string_fromchar(argv[0]);
+	nrm_string_t topic;
+	if (argc == 2)
+		topic = nrm_string_fromchar(argv[1]);
+	else
+		topic = nrm_string_fromchar("");
 	nrm_log_debug("listening to topic: %s\n", topic);
 
 	nrm_client_set_event_listener(client, client_listen_callback);

--- a/src/binaries/nrmc.c
+++ b/src/binaries/nrmc.c
@@ -350,7 +350,7 @@ int client_listen_callback(nrm_string_t sensor_uuid,
 {
 	int64_t nstime = nrm_time_tons(&time);
 	fprintf(stdout, "event: %" PRId64 " %s %s %f\n", nstime, sensor_uuid,
-			scope->uuid, value);
+	        scope->uuid, value);
 	return 0;
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -75,8 +75,8 @@ int nrm_net_sub_init(zsock_t **socket)
 		return 1;
 	/* buffer as many messages as possible */
 	zsock_set_rcvhwm(ret, 0);
-	/* subscribe to everything */
-	zsock_set_subscribe(ret, "");
+	/* subscribe to nothing */
+	zsock_set_subscribe(ret, "null");
 	*socket = ret;
 	return 0;
 }

--- a/tests/cli/full-setup.bats
+++ b/tests/cli/full-setup.bats
@@ -69,6 +69,24 @@ setup_file() {
 	echo "$output" | jq
 }
 
+@test "listen (no argument)" {
+	run -143 --separate-stderr timeout --preserve-status 5 $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc listen
+	event_count=`echo "$output" | wc -l`
+	[ $event_count -ge 1 ]
+}
+
+@test "listen (daemon topic)" {
+	run -143 --separate-stderr timeout --preserve-status 5 $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc listen daemon
+	event_count=`echo "$output" | wc -l`
+	[ $event_count -ge 1 ]
+}
+
+@test "listen (null topic)" {
+	run -143 --separate-stderr timeout --preserve-status 5 $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc listen null
+	event_count=`echo "$output" | wc -l`
+	[ $event_count -eq 1 ]
+}
+
 teardown_file() {
 	run kill $NRM_SETUP_PID
 	run pkill -9 nrm

--- a/tests/net.c
+++ b/tests/net.c
@@ -34,6 +34,7 @@ void setup_pubsub(void)
 	        nrm_net_connect_and_wait(client, NRM_DEFAULT_UPSTREAM_URI,
 	                                 NRM_DEFAULT_UPSTREAM_PUB_PORT),
 	        0);
+	ck_assert_int_eq(nrm_net_sub_set_topic(client, ""), 0);
 	/* subscription is as annoying as usual, can't guarantee that the
 	 * messages are showing up without waiting a bit
 	 */


### PR DESCRIPTION
Change default subscription topic to null, so that clients don't default to subscribing to all messages from the daemon.

Test, and make nrmc listen work.