### PR TITLE
[feature] add event listening to python bindings

### DIFF
--- a/bindings/python/nrm/base.py
+++ b/bindings/python/nrm/base.py
@@ -28,16 +28,27 @@ nrm_uuid = nrm_str
 
 # public struct types
 
+# ctypes.c_time_t is in python 3.12
+if hasattr(ct, "c_time_t"):
+    _time_t = ct.c_c_time_t
+else:
+    # check for 64b system
+    if ct.sizeof(ct.c_void_p) == ct.sizeof(ct.c_int64):
+        _time_t = ct.c_int64
+    else:
+        _time_t = ct.c_int32
+
 
 class nrm_time(ct.Structure):
-    _fields_ = [("tv_sec", ct.c_time_t),
-                ("tv_nsec", ct.c_long)]
+    _fields_ = [("tv_sec", _time_t), ("tv_nsec", ct.c_long)]
+
 
 # function ptr types
 
 
-nrm_client_event_listener_fn = ct.CFUNCTYPE(ct.c_int, nrm_str, nrm_time,
-                                            nrm_scope, ct.c_double)
+nrm_client_event_listener_fn = ct.CFUNCTYPE(
+    ct.c_int, nrm_str, nrm_time, nrm_scope, ct.c_double
+)
 
 # Error types
 

--- a/bindings/python/nrm/base.py
+++ b/bindings/python/nrm/base.py
@@ -26,6 +26,18 @@ nrm_slice = ct.c_void_p
 nrm_vector = ct.c_void_p
 nrm_uuid = nrm_str
 
+# public struct types
+
+
+class nrm_time(ct.Structure):
+    _fields_ = [("tv_sec", ct.c_time_t),
+                ("tv_nsec", ct.c_long)]
+
+# function ptr types
+
+
+nrm_client_event_listener_fn = ct.CFUNCTYPE(ct.c_int, nrm_str, nrm_time,
+                                            nrm_scope, ct.c_double)
 
 # Error types
 

--- a/bindings/python/nrm/client.py
+++ b/bindings/python/nrm/client.py
@@ -22,6 +22,7 @@ from .base import (
     nrm_actuator,
     nrm_scope,
     nrm_slice,
+    nrm_client_event_listener_fn,
     upstream_uri,
     upstream_pub_port,
     upstream_rpc_port,
@@ -64,6 +65,10 @@ nrm_client_add_scope = _nrm_get_function(
 
 nrm_client_add_slice = _nrm_get_function(
     "nrm_client_add_slice", [nrm_client, nrm_slice]
+)
+
+nrm_client_set_event_listener = _nrm_get_function(
+    "nrm_client_set_event_listener", [nrm_client, nrm_client_event_listener_fn]
 )
 
 nrm_sensor_create = _nrm_get_function(
@@ -198,6 +203,15 @@ class Client:
     def add_slice(self, name: str):
         nslice = nrm_slice_create(bytes(name, "utf-8"))  # "slice" is builtin
         nrm_client_add_slice(self.client, nslice)
+
+    def set_event_listener(self, cb):
+
+        # https://stackoverflow.com/questions/2469975/python-objects-as-userdata-in-ctypes-callback-functions
+        def _my_el_wrapper(sensor, time, scope, value):
+            return self.cb(sensor, time, scope, value)
+
+        self.nrmc_callback = nrm_client_event_listener_fn(_my_el_wrapper)
+        nrm_client_set_event_listener(self.client, self.nrmc_callback)
 
     def __del__(self):
         nrm_client_destroy(byref(self.client))

--- a/bindings/python/nrm/client.py
+++ b/bindings/python/nrm/client.py
@@ -213,7 +213,7 @@ class Client:
             try:
                 cb(sensor, time, scope, value)
                 return 0
-            except:
+            except Exception:
                 return -1
 
         self.nrmc_callback = nrm_client_event_listener_fn(_my_el_wrapper)

--- a/bindings/python/tests/test_client.py
+++ b/bindings/python/tests/test_client.py
@@ -8,7 +8,9 @@
 
 from nrm import Client, Setup, Actuator, Sensor, Scope, Slice
 import unittest
+from unittest.mock import Mock
 import os
+import time
 
 options = {"prefix": os.environ.get("ABS_TOP_BUILDDIR")}
 
@@ -68,6 +70,18 @@ class TestClient(unittest.TestCase):
             assert dummy_act.get_value() == 0.0
             assert dummy_act.list_choices() == [0.0, 1.0]
             assert len(dummy_act.get_clientid())
+
+    def test_listen(self):
+        with Setup("nrmd", options=options), Setup(
+            "nrm-dummy-extra", options=options
+        ):
+            client = Client()
+
+            mock = Mock(return_value=None)
+            client.set_event_listener(mock)
+            client.start_event_listener("")
+            time.sleep(1)
+            mock.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ctypes makes the process mostly painless, as we can create arbitrary functions from the prototype function pointer type dynamically.

From a usability point of view, the lack of automatic conversion between ctypes and more pythonic types is starting to look obvious. We should definitely convert stuff like nrm_string and nrm_time.