### PR TITLE
[fix/ci] add checks on daemon config, fix bugs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -212,6 +212,8 @@ endif
 # can't make it work nicely with readthedocs, so use a subdir
 SUBDIRS += doc
 
+EXTRA_DIST += examples
+
 ###############################################################################
 # TESTS
 ###############################################################################

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,6 +1,7 @@
 {
 	"control": {
 		"name": "europar21",
+		"active": false,
 		"inputs": [ { "sensor": "nrm-ompt", "scope": "nrm.hwloc.Machine.0"} ],
 		"outputs": [ "nrm.actuator.rapl" ],
 		"args": {
@@ -11,7 +12,9 @@
 			"Kl": 25.6,
 			"t": 0.33,
 			"e": 0.1,
-			"max": 100
+			"tobj": 10.0,
+			"min": 100.0,
+			"max": 100.0
 		}
 	}
 }

--- a/src/eventbase.c
+++ b/src/eventbase.c
@@ -237,12 +237,12 @@ int nrm_eventbase_pull_timeserie(nrm_eventbase_t *eb,
 	nrm_timeserie_t *ret;
 	nrm_timeserie_create(&ret, sensor_uuid, scope);
 
-	nrm_eb_sensorbase_t *sb;
+	nrm_eb_sensorbase_t *sb = NULL;
 	nrm_hash_find(eb->sensors, sensor_uuid, (void *)&sb);
 	if (sb == NULL)
 		goto end;
 
-	nrm_eb_scopebase_t *sc;
+	nrm_eb_scopebase_t *sc = NULL;
 	nrm_hash_find(sb->scopes, scope->uuid, (void *)&sc);
 	if (sc == NULL)
 		goto end;

--- a/tests/cli/Makefile.am
+++ b/tests/cli/Makefile.am
@@ -6,6 +6,7 @@ AM_COLOR_TESTS = yes
 BATS_TESTS = \
 	     standalone.bats \
 	     daemon-only.bats \
+	     daemon-with-config.bats \
 	     full-setup.bats
 
 TEST_EXTENSIONS = .bats

--- a/tests/cli/bats-driver.sh.in
+++ b/tests/cli/bats-driver.sh.in
@@ -2,6 +2,7 @@
 # none of our bats tests should take more than a few seconds
 export BATS_TEST_TIMEOUT=15
 export ABS_TOP_BUILDDIR=@abs_top_builddir@
+export ABS_TOP_SRCDIR=@abs_top_srcdir@
 export LOG_COMPILER
 export LOG_FLAGS
 export VALGRIND

--- a/tests/cli/daemon-with-config.bats
+++ b/tests/cli/daemon-with-config.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# vim: set ft=bash:
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+	$ABS_TOP_BUILDDIR/nrm-setup -p $ABS_TOP_BUILDDIR -c $ABS_TOP_SRCDIR/examples/config.json -o $BATS_TEST_TMPDIR &
+	NRM_SETUP_PID=$!
+	# wait for nrm-setup to start sleeping
+	while [ ! -e $BATS_TEST_TMPDIR/nrm-setup-ready.log ]; do
+		sleep 1
+	done
+}
+
+@test "inactive" {
+	# completely ignore any exit status on nrmc
+	run $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc tick
+	sleep 1
+	run $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc exit
+	wait $NRM_SETUP_PID
+}
+
+teardown_file() {
+	run pkill -9 nrm
+}

--- a/tests/cli/full-setup.bats
+++ b/tests/cli/full-setup.bats
@@ -17,6 +17,11 @@ setup_file() {
 	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc connect
 }
 
+@test "tick (no config)" {
+	# check if the daemon can still properly tick without a configuration
+	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc tick
+}
+
 @test "list dummy sensor" {
 	# can we list sensors
 	run -0 --separate-stderr $LOG_COMPILER $LOG_FLAGS $ABS_TOP_BUILDDIR/nrmc list-sensors


### PR DESCRIPTION
Fixes a bug with eventbase segfaulting if any of the internal hashes are uninitialized (missing NULL return).

Adds bats tests for simple configurations.